### PR TITLE
No longer uses variables from o-fonts for specifying font-family

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     ".travis.yml"
   ],
   "dependencies": {
-    "o-fonts": "^1.2.0",
+    "o-fonts": "^1.3.0",
     "o-colors": "^2.3.0",
     "o-hoverable": "^0.1.1",
     "o-useragent": ">=0.5.0 <2"

--- a/main.scss
+++ b/main.scss
@@ -6,10 +6,35 @@
 @import "scss/_functions";
 @import "scss/_mixins";
 
+// Force re-draw of web font in Chrome: https://code.google.com/p/chromium/issues/detail?id=336476
+@include oUseragentTarget(chrome) {
+  -webkit-animation-duration: 0.1s;
+  -webkit-animation-name: fontfix;
+  -webkit-animation-iteration-count: 1;
+  -webkit-animation-timing-function: linear;
+  -webkit-animation-delay: 0.1s;
+}
+@mixin oFtTypographyWebkitFontfix() {
+  @at-root {
+    @-webkit-keyframes fontfix {
+      from {
+        opacity: 1;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+  }
+}
+
 @if (not $o-ft-typography-is-silent) {
     @each $usecase in $_o-ft-typography-fontface-usecase-mapping {
         @include oFtTypographyIncludeFont(nth($usecase, 1));
     }
+    body {
+      @extend %o-useragent-chrome;
+    }
+    @include oFtTypographyWebkitFontfix();
 }
 
 @import "scss/headings";

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -1,4 +1,8 @@
-@import "o-fonts/main";
+@mixin _oFtTypographyFont($family, $weight:normal, $style:normal) {
+  font-family: oFontsGetFontFamilyWithFallbacks($family);
+  font-weight: $weight;
+  font-style: $style;
+}
 
 @mixin oFtTypographyFontOffset($offset) {
   @if ($offset > 0) {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -4,31 +4,6 @@ $o-ft-typography-is-silent: true !default;
 
 $_o-ft-typography-selector-prefix: o-ft-typography-;
 
-$_o-ft-typography-heading-xlarge-font: $o-fonts-bentonsans-bold;
-$_o-ft-typography-heading-large-font: $o-fonts-bentonsans-bold;
-$_o-ft-typography-heading-medium-font: $o-fonts-bentonsans-bold;
-$_o-ft-typography-heading-small-font: $o-fonts-bentonsans-bold;
-
-$_o-ft-typography-title-large-font: $o-fonts-millerdisplay-normal;
-$_o-ft-typography-title-medium-font: $o-fonts-millerdisplay-normal;
-$_o-ft-typography-title-small-font: $o-fonts-millerdisplay-normal;
-
-$_o-ft-typography-lead-large-font: $o-fonts-millerdisplay-normal;
-$_o-ft-typography-lead-medium-font: $o-fonts-millerdisplay-normal;
-$_o-ft-typography-lead-small-font: $o-fonts-bentonsans-normal;
-
-$_o-ft-typography-brand-font: $o-fonts-bentonsans-bold;
-$_o-ft-typography-metadata-font: $o-fonts-bentonsans-normal;
-
-$_o-ft-typography-body-font: $o-fonts-sans-serif;
-
-$_o-ft-typography-article-subheading-font: $o-fonts-bentonsans-bold;
-$_o-ft-typography-article-body-font: $o-fonts-serif;
-
-$_o-ft-typography-label-large-font:  $o-fonts-bentonsans-bold;
-$_o-ft-typography-label-medium-font:  $o-fonts-bentonsans-bold;
-$_o-ft-typography-label-small-font:  $o-fonts-bentonsans-normal;
-
 // Use to define font faces that need including for given use cases
 $_o-ft-typography-fontface-usecase-mapping: (
   title             MillerDisplay   normal,
@@ -38,5 +13,9 @@ $_o-ft-typography-fontface-usecase-mapping: (
   heading           BentonSans      bold,
   label             BentonSans      normal,
   label             BentonSans      bold,
-  body              BentonSans      normal
+  body              BentonSans      normal,
+  body              BentonSans      bold,
+  body-article      MillerDisplay   normal,
+  body-article      Clarion         normal,
+  body-article      Clarion         bold
 );

--- a/scss/article_subheadings.scss
+++ b/scss/article_subheadings.scss
@@ -3,8 +3,7 @@
   padding: 5px 0;
   @include oFtTypographyFontSize(16, 20);
   @include oFtTypographyExtend(body__block);
-  font-family: $_o-ft-typography-article-subheading-font;
-  font-weight: bold;
+  @include _oFtTypographyFont(BentonSans, bold);
   color: oColorsGetColorFor(article-subheading-text);
 }
 

--- a/scss/badges.scss
+++ b/scss/badges.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   border-radius: 5px;
   padding: 0 4px;
-  font-family: $o-fonts-bentonsans-bold;
+  @include _oFtTypographyFont(BentonSans, bold);
   font-size: 10px;
   font-weight: normal;
   line-height: 14px;

--- a/scss/body_article.scss
+++ b/scss/body_article.scss
@@ -1,17 +1,15 @@
 @include oFtTypographySelectors(article-body--lead) {
   margin: 0 0 9px 0;
-  border-bottom: 1px dotted oColorsGetColorFor(article-body-lead-border); //
+  border-bottom: 1px dotted oColorsGetColorFor(article-body-lead-border);
   padding: 0 0 14px 0;
-  font-family: $_o-ft-typography-article-body-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(MillerDisplay, normal);
   @include oFtTypographyFontSize(21, 27);
   color: oColorsGetColorFor(article-body-lead-text);
 }
 
 @include oFtTypographySelectors(article-body)  {
   @include oFtTypographyFontSize(16, 24);
-  font-family: $_o-ft-typography-article-body-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(Clarion, normal);
   color: oColorsGetColorFor(article-body-text);
 }
 

--- a/scss/body_general.scss
+++ b/scss/body_general.scss
@@ -1,14 +1,12 @@
 @include oFtTypographySelectors(body--lead) {
-  font-family: $_o-ft-typography-body-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans, normal);
   @include oFtTypographyFontSize(18, 24);
   color: oColorsGetColorFor(body-lead-text);
   -webkit-font-smoothing: antialiased; // This stops the light font looking thicker/fuzzier
 }
 
 @include oFtTypographySelectors(body) {
-  font-family: $_o-ft-typography-body-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans, normal);
   @include oFtTypographyFontSize(14, 20);
   color: oColorsGetColorFor(body-text);
 }

--- a/scss/headings.scss
+++ b/scss/headings.scss
@@ -1,10 +1,11 @@
+
+
 @include oFtTypographySelectors(heading-xlarge) {
   margin: 0 0 16px 0;
   padding: 8px 0 7px 0;
   border-top: 4px solid oColorsGetColorFor(heading-xlarge heading-large heading, border); // Add new use case to o-colors
   border-bottom: 1px dotted oColorsGetColorFor(heading-xlarge heading-large heading, border); // Add new use case to o-colors
-  font-family: $_o-ft-typography-heading-xlarge-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans, bold);
   @include oFtTypographyFontSize(16, 20);
   color: oColorsGetColorFor(heading-xlarge heading, text);
 }
@@ -23,8 +24,7 @@
   padding: 8px 0 7px 0;
   border-top: 4px solid oColorsGetColorFor(heading-large heading, border);
   border-bottom: 1px dotted oColorsGetColorFor(heading-large heading, border);
-  font-family: $_o-ft-typography-heading-large-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans, bold);
   text-transform: uppercase;
   @include oFtTypographyFontSize(14, 20);
   color: oColorsGetColorFor(heading-large heading, text);
@@ -41,8 +41,7 @@
 
 @mixin oFtTypographyHeadingMediumStyles() {
   margin: 0 0 16px 0;
-  font-family: $_o-ft-typography-heading-medium-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans, bold);
   @include oFtTypographyFontSize(13, 20);
   color: oColorsGetColorFor(heading, text);
   text-transform: uppercase;
@@ -59,15 +58,14 @@
 @include oUseragentTarget(ie7 ie8 ie9) {
   @include oFtTypographySelectors(heading-medium) {
     @include oFtTypographyHeadingMediumStyles();
-    border-bottom: 1px solid oColorsGetColorFor(heading-medium heading, border); // TODO: Add new use case for heading-medium-border -> tint2
+    border-bottom: 1px solid oColorsGetColorFor(heading-medium heading, border);
     background-image: none;
   }
 }
 
 @include oFtTypographySelectors(heading-small) {
   margin: 0 0 8px 0;
-  font-family: $_o-ft-typography-heading-small-font;
-  font-weight: bold;
+  @include _oFtTypographyFont(BentonSans, bold);
   @include oFtTypographyFontSize(14, 20);
   color: oColorsGetColorFor(heading, text);
 }

--- a/scss/labels.scss
+++ b/scss/labels.scss
@@ -11,21 +11,18 @@
 
 @include oFtTypographySelectors(label-large) {
   @extend %label-text;
-  font-family: $_o-ft-typography-label-large-font;
-  font-weight: bold;
+  @include _oFtTypographyFont(BentonSans, bold);
   @include oFtTypographyFontSize(16, 21);
 }
 
 @include oFtTypographySelectors(label-medium) {
   @extend %label-text;
-  font-family: $_o-ft-typography-label-medium-font;
-  font-weight: bold;
+  @include _oFtTypographyFont(BentonSans, bold);
   @include oFtTypographyFontSize(14, 17);
 }
 
 @include oFtTypographySelectors(label-small) {
   @extend %label-text;
-  font-family: $_o-ft-typography-label-small-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans, normal);
   @include oFtTypographyFontSize(12, 15);
 }

--- a/scss/leads.scss
+++ b/scss/leads.scss
@@ -1,20 +1,17 @@
 @include oFtTypographySelectors(lead-large) {
-  font-family: $_o-ft-typography-lead-large-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(MillerDisplay, normal);
   @include oFtTypographyFontSize(21, 26);
   color: oColorsGetColorFor(lead-text);
 }
 
 @include oFtTypographySelectors(lead-medium) {
-  font-family: $_o-ft-typography-lead-medium-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(MillerDisplay, normal);
   @include oFtTypographyFontSize(17, 21);
   color: oColorsGetColorFor(lead-medium-text);
 }
 
 @include oFtTypographySelectors(lead-small) {
-  font-family: $_o-ft-typography-lead-small-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans, normal);
   @include oFtTypographyFontSize(13, 17);
   color: oColorsGetColorFor(lead-text);
 }

--- a/scss/metadata.scss
+++ b/scss/metadata.scss
@@ -1,8 +1,7 @@
 @include oFtTypographySelectors(brand)  {
   margin: 0;
   @include oFtTypographyFontSize(12, 14);
-  font-family: $_o-ft-typography-brand-font;
-  font-weight: bold;
+  @include _oFtTypographyFont(BentonSans, bold);
   color: oColorsGetColorFor(brand-text);
 }
 
@@ -18,15 +17,13 @@
 @include oFtTypographySelectors(byline)  {
   margin: 0;
   @include oFtTypographyFontSize(14, 24);
-  font-family: $_o-ft-typography-metadata-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans);
   color: oColorsGetColorFor(byline-text);
 }
 
 @include oFtTypographySelectors(timestamp)  {
   margin: 0;
   @include oFtTypographyFontSize(14, 24);
-  font-family: $_o-ft-typography-metadata-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(BentonSans);
   color: oColorsGetColorFor(timestamp-text);
 }

--- a/scss/titles.scss
+++ b/scss/titles.scss
@@ -1,19 +1,17 @@
 @include oFtTypographySelectors(title-large) {
-  font-family: $_o-ft-typography-title-large-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(MillerDisplay);
   @include oFtTypographyFontSize(30, 36, -5);
   color: oColorsGetColorFor(title-text);
 }
 
 @include oFtTypographySelectors(title-medium) {
-  font-family: $_o-ft-typography-title-medium-font;
-  font-weight: normal;
+  @include _oFtTypographyFont(MillerDisplay);
   @include oFtTypographyFontSize(21, 26);
   color: oColorsGetColorFor(title-text);
 }
 
 @include oFtTypographySelectors(title-small) {
-  font-family: $_o-ft-typography-title-small-font;
+  @include _oFtTypographyFont(MillerDisplay);
   font-weight: bold;
   @include oFtTypographyFontSize(15, 17);
   color: oColorsGetColorFor(title-text);


### PR DESCRIPTION
Instead uses oFontsGetFontFamilyWithFallbacks();

Added rendering fix for webkit bug resulting in web fonts not showing.
