### PR TITLE
Fontless headings

### DIFF
--- a/demos/headings.html
+++ b/demos/headings.html
@@ -19,12 +19,12 @@
 <div class="o-ft-typography-heading4">Heading 4 <a href="#">Link</a></div>
 <div class="o-ft-typography-heading5">Heading 5 <a href="#">Link</a></div>
 <div class="o-ft-typography-heading6">Heading 6 <a href="#">Link</a></div>
-<div class="o-ft-typography-heading1-layout">Heading 1 (layout styles only)</div>
-<div class="o-ft-typography-heading2-layout">Heading 2 (layout styles only)</div>
-<div class="o-ft-typography-heading3-layout">Heading 3 (layout styles only)</div>
-<div class="o-ft-typography-heading4-layout">Heading 4 (layout styles only)</div>
-<div class="o-ft-typography-heading5-layout">Heading 5 (layout styles only)</div>
-<div class="o-ft-typography-heading6-layout">Heading 6 (layout styles only)</div>
+<div class="o-ft-typography-heading1-layout"><span class="o-ft-typography-heading1-text">Heading 1</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading2-layout"><span class="o-ft-typography-heading2-text">Heading 2</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading3-layout"><span class="o-ft-typography-heading3-text">Heading 3</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading4-layout"><span class="o-ft-typography-heading4-text">Heading 4</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading5-layout"><span class="o-ft-typography-heading5-text">Heading 5</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading6-layout"><span class="o-ft-typography-heading6-text">Heading 6</span><span>With unstyled sub-content</span></div>
     
     <script src='http://registry.origami.ft.com/embedapi?autoload=resize'></script>
 </body>

--- a/demos/src/headings.mustache
+++ b/demos/src/headings.mustache
@@ -5,9 +5,9 @@
 <div class="o-ft-typography-heading4">Heading 4 <a href="#">Link</a></div>
 <div class="o-ft-typography-heading5">Heading 5 <a href="#">Link</a></div>
 <div class="o-ft-typography-heading6">Heading 6 <a href="#">Link</a></div>
-<div class="o-ft-typography-heading1-layout">Heading 1 (layout styles only)</div>
-<div class="o-ft-typography-heading2-layout">Heading 2 (layout styles only)</div>
-<div class="o-ft-typography-heading3-layout">Heading 3 (layout styles only)</div>
-<div class="o-ft-typography-heading4-layout">Heading 4 (layout styles only)</div>
-<div class="o-ft-typography-heading5-layout">Heading 5 (layout styles only)</div>
-<div class="o-ft-typography-heading6-layout">Heading 6 (layout styles only)</div>
+<div class="o-ft-typography-heading1-layout"><span class="o-ft-typography-heading1-text">Heading 1</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading2-layout"><span class="o-ft-typography-heading2-text">Heading 2</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading3-layout"><span class="o-ft-typography-heading3-text">Heading 3</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading4-layout"><span class="o-ft-typography-heading4-text">Heading 4</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading5-layout"><span class="o-ft-typography-heading5-text">Heading 5</span><span>With unstyled sub-content</span></div>
+<div class="o-ft-typography-heading6-layout"><span class="o-ft-typography-heading6-text">Heading 6</span><span>With unstyled sub-content</span></div>

--- a/scss/headings.scss
+++ b/scss/headings.scss
@@ -5,13 +5,16 @@
   border-bottom: 1px dotted oColorsGetColorFor(heading1 heading-large heading, border); // Add new use case to o-colors
 }
 
-
-@include oFtTypographySelectors(heading1) {
-  @extend #{oFtGetPrefixedPlaceholders(heading1-layout)};
+@include oFtTypographySelectors(heading1-text) {
   @include _oFtTypographyFont(BentonSans, bold);
   @include oFtTypographyFontSize(16, 20);
   color: oColorsGetColorFor(heading-xlarge heading, text);
   @include _oFtTypographyLinkStyle(oColorsGetColorFor(heading-large heading, text), oColorsGetColorFor(link, text));
+}
+
+@include oFtTypographySelectors(heading1) {
+  @extend #{oFtGetPrefixedPlaceholders(heading1-layout)};
+  @extend #{oFtGetPrefixedPlaceholders(heading1-text)};
 }
 
 @include oFtTypographySelectors(heading2-layout) {
@@ -21,13 +24,17 @@
   border-bottom: 1px dotted oColorsGetColorFor(heading2 heading-large heading, border);
 }
 
-@include oFtTypographySelectors(heading2) {
-  @extend #{oFtGetPrefixedPlaceholders(heading2-layout)};
+@include oFtTypographySelectors(heading2-text) {
   @include _oFtTypographyFont(BentonSans, bold);
   text-transform: uppercase;
   @include oFtTypographyFontSize(14, 20);
   color: oColorsGetColorFor(heading-large heading, text);
   @include _oFtTypographyLinkStyle(oColorsGetColorFor(heading2 heading-large heading, text), oColorsGetColorFor(link, text));
+}
+
+@include oFtTypographySelectors(heading2) {
+  @extend #{oFtGetPrefixedPlaceholders(heading2-layout)};
+  @extend #{oFtGetPrefixedPlaceholders(heading2-text)};
 }
 
 @mixin oFtTypographyHeading3and4Layout() {
@@ -52,10 +59,14 @@
   }
 }
 
-@include oFtTypographySelectors(heading3) {
+@include oFtTypographySelectors(heading3-text) {
   @include oFtTypographyHeading3and4Text();
-  @extend #{oFtGetPrefixedPlaceholders(heading3-layout)};
   @include _oFtTypographyLinkStyle(oColorsGetColorFor(heading3 article-subheading, text), oColorsGetColorFor(link, text));
+}
+
+@include oFtTypographySelectors(heading3) {
+  @extend #{oFtGetPrefixedPlaceholders(heading3-layout)};
+  @extend #{oFtGetPrefixedPlaceholders(heading3-text)};
 }
 
 @include oFtTypographySelectors(heading4-layout) {
@@ -65,10 +76,14 @@
   }
 }
 
-@include oFtTypographySelectors(heading4) {
+@include oFtTypographySelectors(heading4-text) {
   @include oFtTypographyHeading3and4Text();
-  @extend #{oFtGetPrefixedPlaceholders(heading4-layout)};
   @include _oFtTypographyLinkStyle(oColorsGetColorFor(heading4 article-subheading, text), oColorsGetColorFor(link, text));
+}
+
+@include oFtTypographySelectors(heading4) {
+  @extend #{oFtGetPrefixedPlaceholders(heading4-layout)};
+  @extend #{oFtGetPrefixedPlaceholders(heading4-text)};
 }
 
 
@@ -89,12 +104,17 @@
   background-position: bottom right;
   background-repeat: no-repeat;
   background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABdwAAAAPAQMAAADEaZ8BAAAABlBMVEUAAADs3s8R/6e7AAAAAXRSTlMAQObYZgAAADBJREFUSMdj+D90QcNQdvyDUccPEPgw6njiwKjjh43jh3SGHdKOb2AYBaNgFAwdAACrOE9c1sAQpgAAAABJRU5ErkJggg==');
+
+}
+
+@include oFtTypographySelectors(heading5-text) {
+  @include oFtTypographyHeading5TextStyles();
+  @include oFtTypographyFauxTextBackground(oColorsGetColorFor(page, background));
 }
 
 @include oFtTypographySelectors(heading5) {
-  @include oFtTypographyHeading5TextStyles();
   @extend #{oFtGetPrefixedPlaceholders(heading5-layout)};
-  @include oFtTypographyFauxTextBackground(oColorsGetColorFor(page, background));
+  @extend #{oFtGetPrefixedPlaceholders(heading5-text)};
 }
 
 @include oUseragentTarget(ie7 ie8 ie9) {
@@ -109,12 +129,17 @@
   margin: 0 0 8px 0;
 }
 
-@include oFtTypographySelectors(heading6) {
-  @extend #{oFtGetPrefixedPlaceholders(heading6-layout)};
+@include oFtTypographySelectors(heading6-text) {
+  margin: 0 0 8px 0;
   @include _oFtTypographyFont(BentonSans, bold);
   @include oFtTypographyFontSize(14, 20);
   color: oColorsGetColorFor(heading6 heading, text);
   @include _oFtTypographyLinkStyle(oColorsGetColorFor(link, text), oColorsGetColorFor(link-hover, text));
+}
+
+@include oFtTypographySelectors(heading6) {
+  @extend #{oFtGetPrefixedPlaceholders(heading6-layout)};
+  @extend #{oFtGetPrefixedPlaceholders(heading6-text)};
 }
 
 // Deprecated placeholders & classes for backwards compatibility


### PR DESCRIPTION
This makes it a lot easier to e.g style the fast ft headings, where the basic style is that of a heading, but possibly wrapping additional content which shouldn't be styled with the heading's fonts. It's particularly useful for avoiding having to override hover effects on links, with the detrimental effect that has on specicifity

Now there are additional classes and placeholders available:
- `o-ft-typography-headingN`
- `o-ft-typography-headingN-layout`
- `o-ft-typography-headingN-text`

So it's then possible to do

``` html
<div class="o-ft-typography-heading1-layout">
    <span class="o-ft-typography-heading1-text">Heading 1</span>
    <span>With alternatively styled sub-content</span>
</div>
```

Does this seem ok? @dan-searle @danskinner 
