### PR TITLE
added styles for b and i tags

### DIFF
--- a/scss/_wrapped_common.scss
+++ b/scss/_wrapped_common.scss
@@ -1,9 +1,11 @@
 @mixin oFtTypographyCommonWrappedBodyStyles() {
-  strong {
+  strong,
+  b {
     @include oFtTypographyExtend(body--bold);
   }
 
-  em {
+  em,
+  i {
     @include oFtTypographyExtend(body--italic);
   }
 


### PR DESCRIPTION
In the html5 spec `<b>` and `<i>` tags have their semantics properly defined (can't be bothered finding the reference, but it's something along the lines of 'should be used to highlight text when no change in tone of voice is implied' e.g 

``` html
<p>Post with id <b>12345</b> could not be found</p>
```

So this PR extends strong and em styles to apply to b and i.

NB - there's a twin PR on o-ft-icons to add !important to font-style rules https://github.com/Financial-Times/o-ft-icons/pull/20 so that icons using an `<i>` tag don't get italicised
