### PR TITLE
Prompt users to update o-typography to a newer version

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -20,6 +20,8 @@
 @import "scss/badges";
 @import "scss/classes";
 
+@warn 'Please update o-typography to version 2, then rename oFtTypography* mixins to oTypography* and o-ft-typography-* classes to o-typography-*.';
+
 // Switch off component deprecation warnings
 $_o-ft-typography-deprecation-warnings: false;
 


### PR DESCRIPTION
The module would grow too big if we follow the normal deprecation path, where o-typography and o-ft-typography classes would cohabit, so I propose we simply prompt users to update to a newer version.

(the low adoption rate makes it okay IMHO)