### PR TITLE
Add bold by fixing bug

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -18,7 +18,7 @@
 ///
 /// @return {Map}
 ///
-@function get-scale($name, $font-scale: $font-scale) {
+@function get-scale($name, $font-scale: $o-typography-font-scale) {
     @return map-get($font-scale, $name);
 }
 
@@ -37,7 +37,7 @@
 ///
 /// @return {Map}
 ///
-@function get-scale-level($name, $level, $font-scale: $font-scale) {
+@function get-scale-level($name, $level, $font-scale: $o-typography-font-scale) {
     @return map-get(get-scale($name, $font-scale), $level);
 }
 
@@ -73,7 +73,7 @@
 ///
 /// @return {Number}
 ///
-@function get-font-size($name, $level, $font-scale: $font-scale) {
+@function get-font-size($name, $level, $font-scale: $o-typography-font-scale) {
     @return convert-to-px(map-get(get-scale-level($name, $level, $font-scale), font-size));
 }
 
@@ -93,7 +93,7 @@
 ///
 /// @return {Number}
 ///
-@function get-line-height($name, $level, $font-scale: $font-scale) {
+@function get-line-height($name, $level, $font-scale: $o-typography-font-scale) {
     @return convert-to-px(map-get(get-scale-level($name, $level, $font-scale), line-height));
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -8,7 +8,7 @@
 $o-typography-is-silent: true !default;
 
 // serifDisplayBoldItalic is deprecated and will be removed
-$font-scale: (
+$o-typography-font-scale: (
 	sans: (
 		xl: (font-size: 40, line-height: 40),
 		l: (font-size: 26, line-height: 27),
@@ -94,6 +94,20 @@ $font-scale: (
 		xs: (font-size: 12, line-height: 12)
 	)
 );
+
+// Previously, $o-typography-font-scale was called $font-scale. In order to not
+// make this rename a breaking change, check if anything is overriding
+// $font-scale and if it is, set $o-typography-font-scale to that value.
+// If it isn't, set $font-scale to $o-typography-font-scale in case anything is
+// reading it
+
+@if variable-exists(font-scale) {
+	$o-typography-font-scale: $font-scale;
+} @else {
+ 	$font-scale: $o-typography-font-scale;
+}
+
+
 
 $o-typography-sans: oFontsGetFontFamilyWithFallbacks(MetricWeb) !default;
 $o-typography-serif: oFontsGetFontFamilyWithFallbacks(FinancierTextWeb) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -7,31 +7,6 @@
 /// @type Bool
 $o-typography-is-silent: true !default;
 
-$o-fonts-families: (
-	MetricWeb: (
-		font-family: 'MetricWeb, sans-serif',
-		variants: (
-			(weight: light, style: normal),
-			(weight: light, style: italic),
-			(weight: semibold, style: normal),
-		)
-	),
-	FinancierDisplayWeb: (
-		font-family: 'FinancierDisplayWeb, Georgia, serif',
-		variants: (
-			(weight: regular, style: normal),
-			(weight: medium, style: italic),
-			(weight: light, style: italic),
-		)
-	),
-	FinancierTextWeb: (
-		font-family: 'FinancierTextWeb, Georgia, serif',
-		variants: (
-			(weight: regular, style: normal),
-		)
-	)
-);
-
 // serifDisplayBoldItalic is deprecated and will be removed
 $font-scale: (
 	sans: (


### PR DESCRIPTION
$o-fonts-families is defined in _variables.scss and therefore overwrites the $o-fonts-families definition in o-fonts. We shouldn't be overwriting this in o-typography.

This PR:
- deletes the redefinition of $o-fonts-families so fonts available will be those defined in o-fonts
- adds in appropriate namespacing for $font-scale, but renaming it $o-typography-font-scale