### PR TITLE
Progressive font functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,86 @@ When running in silent mode, o-typography does not load web fonts, products shou
 
 When running in non-silent mode, o-typography loads all web fonts which are used.
 
+### Progressively loading web fonts
+
+One of the drawbacks of using web fonts is some browsers hide the text while the font is downloading (Flash of Invisible Text, aka FOIT). A common pattern for avoiding this is to initially use a system fallback font, and once we know the web font has loaded, add a class to the `html` element and use this to 'upgrade' to the web font, e.g.
+
+```
+.text {
+    font-family: serif;
+}
+
+.font-loaded-serif .text {
+    font-family: FinancierDisplayWeb,serif;
+}
+```
+
+In this case we added a `font-loaded-serif` class to the `html` element once we were sure the web font `FinancierDisplayWeb` was downloaded.
+
+To help with this pattern, each `oTypographyXDisplayItalic` mixin takes a second argument, `$load-progressively`, which, if set to `true`, outputs css in the above format.
+
+Initially we need to set which fonts we want to follow this pattern, by setting the `$o-typography-progressive-fonts` variable
+
+We can also override what the 'loaded' class is prefixed with; `$o-typography-loaded-prefix` (default is `o-typography-loaded`)
+
+A further thing to note is the fallback fonts are generally of a different size to the webfont, so we also scale the font, e.g.
+
+```
+.text {
+    font-family: serif;
+    font-size: 18px;
+    line-height: 24px;
+}
+
+.font-loaded-serif .text {
+    font-family: FinancierDisplayWeb,serif;
+    font-size: 20px
+}
+```
+
+When using the `oTypographyXDisplayItalicSize` mixin, a second argument `$with-progressive-size` can be supplied to scale fonts
+
+
+So as a full example,
+
+```
+$o-typography-progressive-fonts: sansData, serifDisplay;
+$o-typography-loaded-prefix: 'loaded-font';
+
+.foo {
+    @include oTypographySansData(m, $load-progressively: true);
+}
+
+.bar {
+    @include oTypographySerifDisplayItalic(m, $load-progressively: true);
+}
+```
+
+compiles to
+
+```
+.foo {
+    font-family: sans-serif;
+    font-size: 12.18px;
+    line-height: 16px;
+    font-weight: 400;
+}
+
+.loaded-font-sansData .foo {
+    font-family: MetricWeb,sans-serif;
+    font-size: 14px;
+}
+
+.bar {
+    font-family: FinancierDisplayWeb,serif;
+    font-size: 20px;
+    line-height: 22px;
+    font-style: italic;
+    font-weight: 200;
+}
+```
+
+
 ----
 
 ## License

--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ When running in non-silent mode, o-typography loads all web fonts which are used
 
 ### Progressively loading web fonts
 
+**Note: this functionality is not available when using the build service**
+
 One of the drawbacks of using web fonts is some browsers hide the text while the font is downloading (Flash of Invisible Text, aka FOIT). A common pattern for avoiding this is to initially use a system fallback font, and once we know the web font has loaded, add a class to the `html` element and use this to 'upgrade' to the web font, e.g.
 
 ```
@@ -302,7 +304,7 @@ To help with this pattern, each `oTypographyXDisplayItalic` mixin takes a second
 
 Initially we need to set which fonts we want to follow this pattern, by setting the `$o-typography-progressive-fonts` variable
 
-We can also override what the 'loaded' class is prefixed with; `$o-typography-loaded-prefix` (default is `o-typography-loaded`)
+We can also override what the 'loaded' class is prefixed with; `$o-typography-loaded-prefix` (default is `o-typography--loaded`)
 
 A further thing to note is the fallback fonts are generally of a different size to the webfont, so we also scale the font, e.g.
 
@@ -360,7 +362,6 @@ compiles to
     font-weight: 200;
 }
 ```
-
 
 ----
 

--- a/main.scss
+++ b/main.scss
@@ -10,6 +10,7 @@
 @import 'scss/helpers';
 @import 'scss/variables';
 @import 'scss/type_matrix';
+@import 'scss/progressive-font';
 
 @import 'scss/body_common';
 @import 'scss/body_general';
@@ -69,7 +70,7 @@
 		@include oTypographyLead;
 	}
 	.o-typography-lead--small {
-		@include oTypographyLeadSmall;	
+		@include oTypographyLeadSmall;
 	}
 	.o-typography-block {
 		@include oTypographyBodyBlock;

--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -73,8 +73,13 @@
 ///
 /// @return {Number}
 ///
-@function get-font-size($name, $level, $font-scale: $o-typography-font-scale) {
-    @return convert-to-px(map-get(get-scale-level($name, $level, $font-scale), font-size));
+@function get-font-size($name, $level, $font-scale: $o-typography-font-scale, $is-fallback-font: false) {
+	$scale-by: if(
+		$is-fallback-font,
+		map-get(map-get($_o-typography-progressive-font-fallbacks, $name), 'fallback-scale'),
+		1
+	);
+    @return convert-to-px(map-get(get-scale-level($name, $level, $font-scale), font-size) * $scale-by);
 }
 
 ///
@@ -112,4 +117,9 @@
         $value: if(unitless($value), $value * 1px, $value);
     }
     @return $value;
+}
+
+@function scale-fallback-font-size($name, $size) {
+	$scale-by: map-get(map-get($_o-typography-progressive-font-fallbacks, $name), 'fallback-scale');
+	@return $size * $scale-by;
 }

--- a/scss/_progressive-font.scss
+++ b/scss/_progressive-font.scss
@@ -2,96 +2,69 @@ $_o-typography-progressive-font-fallbacks: (
 	sans: (
 		font: $o-typography-sans,
 		fallback: sans-serif,
-		weight: 'light',
-		type: sans,
 		fallback-scale: 0.87
 	),
 	sansBold: (
 		font: $o-typography-sans,
 		fallback: sans-serif,
-		weight: 'semibold',
-		type: sans,
 		fallback-scale: 0.83
 	),
 	sansData: (
 		font: $o-typography-sans,
 		fallback: sans-serif,
-		weight: 'regular',
-		type: sans,
 		fallback-scale: 0.87
 	),
 	sansDataBold: (
 		font: $o-typography-sans,
 		fallback: sans-serif,
-		weight: 'semibold',
-		type: sans,
 		fallback-scale: 0.83
 	),
 	sansDataItalic: (
 		font: $o-typography-sans,
 		fallback: sans-serif,
-		weight: 'regular',
-		type: sans,
 		fallback-scale: 0.87
 	),
 	serif: (
 		font: $o-typography-serif,
 		fallback: serif,
-		weight: 'regular',
-		type: serif,
 		fallback-scale: 0.84
 	),
 	serifBold: (
 		font: $o-typography-serif,
 		fallback: serif,
-		weight: 'medium',
-		type: serif,
 		fallback-scale: 0.84
 	),
 	serifItalic: (
 		font: $o-typography-serif,
 		fallback: serif,
-		weight: 'regular',
-		type: serif,
 		fallback-scale: 0.84
 	),
 	serifDisplay: (
 		font: $o-typography-serif-display,
 		fallback: serif,
-		weight: 'regular',
-		type: serif-display,
 		fallback-scale: 0.9
 	),
 	serifDisplayBold: (
 		font: $o-typography-serif-display,
 		fallback: serif,
-		weight: 'semibold',
-		type: serif-display,
 		fallback-scale: 0.9
 	),
 	serifDisplayItalic: (
 		font: $o-typography-serif-display,
 		fallback: serif,
-		weight: 'regular',
-		type: serif-display,
 		fallback-scale: 0.9
 	)
 );
 
 @mixin oTypographyProgressiveFont($font, $level) {
 	$font-config: map-get($_o-typography-progressive-font-fallbacks, $font);
-	$progressive-font: map-get($o-typography-progressive-fonts, map-get($font-config, 'type'));
-	$is-progressive: if(
-		$progressive-font,
-		index($progressive-font, map-get($font-config, 'weight')),
-		null
-	);
+	$is-progressive: index($o-typography-progressive-fonts, $font);
 
 	@if $is-progressive {
 		font-family: map-get($font-config, 'fallback');
 		@include font-size(get-font-size($font, $level, $is-fallback-font: true), get-line-height($font, $level));
 
-		.loaded-#{map-get($font-config, 'type')}-#{map-get($font-config, 'weight')} & {
+		.loaded-#{$font} & {
 			font-family: map-get($font-config, 'font');
 			font-size: get-font-size($font, $level);
 		}
@@ -105,7 +78,7 @@ $_o-typography-progressive-font-fallbacks: (
 	$font-config: map-get($_o-typography-progressive-font-fallbacks, $font);
 	font-size: scale-fallback-font-size($font, $size);
 
-	.loaded-#{map-get($font-config, 'type')}-#{map-get($font-config, 'weight')} & {
+	.loaded-#{$font} & {
 		font-size: $size;
 	}
 }

--- a/scss/_progressive-font.scss
+++ b/scss/_progressive-font.scss
@@ -78,7 +78,7 @@ $_o-typography-progressive-font-fallbacks: (
 		font-family: map-get($font-config, 'fallback');
 		@include font-size(get-font-size($font, $level, $is-fallback-font: true), get-line-height($font, $level));
 
-		.loaded-#{$font} & {
+		.#{$o-typography-loaded-prefix}-#{$font} & {
 			font-family: map-get($font-config, 'font');
 			font-size: get-font-size($font, $level);
 		}
@@ -103,7 +103,7 @@ $_o-typography-progressive-font-fallbacks: (
 	$font-config: map-get($_o-typography-progressive-font-fallbacks, $font);
 	font-size: scale-fallback-font-size($font, $size);
 
-	.loaded-#{$font} & {
+	.#{$o-typography-loaded-prefix}-#{$font} & {
 		font-size: $size;
 	}
 }

--- a/scss/_progressive-font.scss
+++ b/scss/_progressive-font.scss
@@ -1,7 +1,7 @@
 $_o-typography-progressive-font-fallbacks: (
 	sans: (
 		font: $o-typography-sans,
-		fallback: sans
+		fallback: sans-serif
 	),
 	serif: (
 		font: $o-typography-serif,

--- a/scss/_progressive-font.scss
+++ b/scss/_progressive-font.scss
@@ -1,0 +1,34 @@
+$_o-typography-progressive-font-fallbacks: (
+	sans: (
+		font: $o-typography-sans,
+		fallback: sans
+	),
+	serif: (
+		font: $o-typography-serif,
+		fallback: serif
+	),
+	serif-display: (
+		font: $o-typography-serif-display,
+		fallback: serif
+	)
+);
+
+@mixin oTypographyProgressiveFont($font, $weight) {
+	$font-config: map-get($_o-typography-progressive-font-fallbacks, $font);
+	$progressive-font: map-get($o-typography-progressive-fonts, $font);
+	$is-progressive: if(
+		$progressive-font,
+		index($progressive-font, $weight),
+		null
+	);
+
+	@if $is-progressive {
+		font-family: map-get($font-config, 'fallback');
+
+		.loaded-#{$font}-#{$weight} & {
+			font-family: map-get($font-config, 'font');
+		}
+	} @else {
+		font-family: map-get($font-config, 'font');
+	}
+}

--- a/scss/_progressive-font.scss
+++ b/scss/_progressive-font.scss
@@ -1,34 +1,104 @@
 $_o-typography-progressive-font-fallbacks: (
 	sans: (
 		font: $o-typography-sans,
-		fallback: sans-serif
+		fallback: sans-serif,
+		weight: 'light',
+		type: sans,
+		fallback-scale: 0.87
+	),
+	sansBold: (
+		font: $o-typography-sans,
+		fallback: sans-serif,
+		weight: 'semibold',
+		type: sans,
+		fallback-scale: 0.83
+	),
+	sansData: (
+		font: $o-typography-sans,
+		fallback: sans-serif,
+		weight: 'regular',
+		type: sans,
+		fallback-scale: 0.87
+	),
+	sansDataBold: (
+		font: $o-typography-sans,
+		fallback: sans-serif,
+		weight: 'semibold',
+		type: sans,
+		fallback-scale: 0.83
+	),
+	sansDataItalic: (
+		font: $o-typography-sans,
+		fallback: sans-serif,
+		weight: 'regular',
+		type: sans,
+		fallback-scale: 0.87
 	),
 	serif: (
 		font: $o-typography-serif,
-		fallback: serif
+		fallback: serif,
+		weight: 'regular',
+		type: serif,
+		fallback-scale: 0.84
 	),
-	serif-display: (
+	serifBold: (
+		font: $o-typography-serif,
+		fallback: serif,
+		weight: 'medium',
+		type: serif,
+		fallback-scale: 0.84
+	),
+	serifItalic: (
+		font: $o-typography-serif,
+		fallback: serif,
+		weight: 'regular',
+		type: serif,
+		fallback-scale: 0.84
+	),
+	serifDisplay: (
 		font: $o-typography-serif-display,
-		fallback: serif
+		fallback: serif,
+		weight: 'regular',
+		type: serif-display,
+		fallback-scale: 0.9
+	),
+	serifDisplayBold: (
+		font: $o-typography-serif-display,
+		fallback: serif,
+		weight: 'semibold',
+		type: serif-display,
+		fallback-scale: 0.9
 	)
 );
 
-@mixin oTypographyProgressiveFont($font, $weight) {
+@mixin oTypographyProgressiveFont($font, $level) {
 	$font-config: map-get($_o-typography-progressive-font-fallbacks, $font);
-	$progressive-font: map-get($o-typography-progressive-fonts, $font);
+	$progressive-font: map-get($o-typography-progressive-fonts, map-get($font-config, 'type'));
 	$is-progressive: if(
 		$progressive-font,
-		index($progressive-font, $weight),
+		index($progressive-font, map-get($font-config, 'weight')),
 		null
 	);
 
 	@if $is-progressive {
 		font-family: map-get($font-config, 'fallback');
+		@include font-size(get-font-size($font, $level, $is-fallback-font: true), get-line-height($font, $level));
 
-		.loaded-#{$font}-#{$weight} & {
+		.loaded-#{map-get($font-config, 'type')}-#{map-get($font-config, 'weight')} & {
 			font-family: map-get($font-config, 'font');
+			font-size: get-font-size($font, $level);
 		}
 	} @else {
 		font-family: map-get($font-config, 'font');
+		@include font-size(get-font-size($font, $level), get-line-height($font, $level));
+	}
+}
+
+@mixin oTypographyFallbackFontSize($font, $size) {
+	$font-config: map-get($_o-typography-progressive-font-fallbacks, $font);
+	font-size: scale-fallback-font-size($font, $size);
+
+	.loaded-#{map-get($font-config, 'type')}-#{map-get($font-config, 'weight')} & {
+		font-size: $size;
 	}
 }

--- a/scss/_progressive-font.scss
+++ b/scss/_progressive-font.scss
@@ -68,6 +68,13 @@ $_o-typography-progressive-font-fallbacks: (
 		weight: 'semibold',
 		type: serif-display,
 		fallback-scale: 0.9
+	),
+	serifDisplayItalic: (
+		font: $o-typography-serif-display,
+		fallback: serif,
+		weight: 'regular',
+		type: serif-display,
+		fallback-scale: 0.9
 	)
 );
 

--- a/scss/_progressive-font.scss
+++ b/scss/_progressive-font.scss
@@ -56,6 +56,20 @@ $_o-typography-progressive-font-fallbacks: (
 	)
 );
 
+///
+/// Adjust the font to sans and set the size / line-height
+///
+/// @param {String} $font - Accepts sans, sansBold, sansData, sansDataBold, etc.
+/// @param {String} $level - Accepts xl, l, m, s, xs
+///
+/// @example
+///  @include oTypographyProgressiveFont(sansSerif, xl);
+///
+/// @requires {mixin} font-size
+/// @requires {function} font-size
+/// @requires {function} get-font-size
+/// @requires {function} get-line-height
+///
 @mixin oTypographyProgressiveFont($font, $level) {
 	$font-config: map-get($_o-typography-progressive-font-fallbacks, $font);
 	$is-progressive: index($o-typography-progressive-fonts, $font);
@@ -74,6 +88,17 @@ $_o-typography-progressive-font-fallbacks: (
 	}
 }
 
+///
+/// Sets the font's size / line-height, adjust the fallback font's size appropriately
+///
+/// @param {String} $font - Accepts sans, sansBold, sansData, sansDataBold, etc.
+/// @param {String} $size - Font size, e.g. 12px
+///
+/// @example
+///  @include oTypographyFallbackFontSize(sansSerif, 12px);
+///
+/// @requires {function} scale-fallback-font-size
+///
 @mixin oTypographyFallbackFontSize($font, $size) {
 	$font-config: map-get($_o-typography-progressive-font-fallbacks, $font);
 	font-size: scale-fallback-font-size($font, $size);

--- a/scss/_type_matrix.scss
+++ b/scss/_type_matrix.scss
@@ -31,9 +31,13 @@
 ///
 /// @requires {mixin} oTypographySansSize
 ///
-@mixin oTypographySans($level) {
+@mixin oTypographySans($level, $load-progressively: false) {
 	@include oTypographySansSize($level);
-	@include oTypographyProgressiveFont('sans', 'light');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('sans', 'light');
+	} else {
+		font-family: $o-typography-sans;
+	}
 	font-weight: oFontsWeight(light);
 }
 
@@ -63,9 +67,13 @@
 ///
 /// @requires {mixin} oTypographySansBoldSize
 ///
-@mixin oTypographySansBold($level) {
+@mixin oTypographySansBold($level, $load-progressively: false) {
 	@include oTypographySansBoldSize($level);
-	@include oTypographyProgressiveFont('sans', 'semibold');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('sans', 'semibold');
+	} else {
+		font-family: $o-typography-sans;
+	}
 	font-weight: oFontsWeight(semibold);
 }
 
@@ -95,9 +103,13 @@
 ///
 /// @requires {mixin} oTypographySansDataSize
 ///
-@mixin oTypographySansData($level) {
+@mixin oTypographySansData($level, $load-progressively: false) {
 	@include oTypographySansDataSize($level);
-	@include oTypographyProgressiveFont('sans', 'regular');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('sans', 'regular');
+	} else {
+		font-family: $o-typography-sans;
+	}
 	font-weight: oFontsWeight(regular);
 }
 
@@ -127,9 +139,13 @@
 ///
 /// @requires {mixin} oTypographySansDataBoldSize
 ///
-@mixin oTypographySansDataBold($level) {
+@mixin oTypographySansDataBold($level, $load-progressively: false) {
 	@include oTypographySansDataBoldSize($level);
-	@include oTypographyProgressiveFont('sans', 'semibold');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('sans', 'semibold');
+	} else {
+		font-family: $o-typography-sans;
+	}
 	font-weight: oFontsWeight(semibold);
 }
 
@@ -159,9 +175,13 @@
 ///
 /// @requires {mixin} oTypographySansDataItalicSize
 ///
-@mixin oTypographySansDataItalic($level) {
+@mixin oTypographySansDataItalic($level, $load-progressively: false) {
 	@include oTypographySansDataItalicSize($level);
-	@include oTypographyProgressiveFont('sans', 'regular');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('sans', 'regular');
+	} else {
+		font-family: $o-typography-sans;
+	}
 	font-weight: oFontsWeight(regular);
 	font-style: italic;
 }
@@ -193,9 +213,13 @@
 ///
 /// @requires {mixin} oTypographySerifSize
 ///
-@mixin oTypographySerif($level) {
+@mixin oTypographySerif($level, $load-progressively: false) {
 	@include oTypographySerifSize($level);
-	@include oTypographyProgressiveFont('serif', 'regular');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('serif', 'regular');
+	} else {
+		font-family: $o-typography-serif;
+	}
 	font-weight: oFontsWeight(regular);
 }
 
@@ -225,9 +249,13 @@
 ///
 /// @requires {mixin} oTypographySerifBoldSize
 ///
-@mixin oTypographySerifBold($level) {
+@mixin oTypographySerifBold($level, $load-progressively: false) {
 	@include oTypographySerifBoldSize($level);
-	@include oTypographyProgressiveFont('serif', 'bold');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('serif', 'bold');
+	} else {
+		font-family: $o-typography-serif;
+	}
 	font-weight: oFontsWeight(bold);
 }
 
@@ -257,9 +285,13 @@
 ///
 /// @requires {mixin} oTypographySerifItalicSize
 ///
-@mixin oTypographySerifItalic($level) {
+@mixin oTypographySerifItalic($level, $load-progressively: false) {
 	@include oTypographySerifItalicSize($level);
-	@include oTypographyProgressiveFont('serif', 'light');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('serif', 'light');
+	} else {
+		font-family: $o-typography-serif;
+	}
 	font-style: italic;
 	font-weight: oFontsWeight(light);
 }
@@ -290,9 +322,13 @@
 ///
 /// @requires {mixin} oTypographySerifDisplaySize
 ///
-@mixin oTypographySerifDisplay($level) {
+@mixin oTypographySerifDisplay($level, $load-progressively: false) {
 	@include oTypographySerifDisplaySize($level);
-	@include oTypographyProgressiveFont('serif-display', 'regular');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('serif-display', 'regular');
+	} else {
+		font-family: $o-typography-serif-display;
+	}
 	font-weight: oFontsWeight(regular);
 }
 
@@ -322,9 +358,13 @@
 ///
 /// @requires {mixin} oTypographySerifDisplayBoldSize
 ///
-@mixin oTypographySerifDisplayBold($level) {
+@mixin oTypographySerifDisplayBold($level, $load-progressively: false) {
 	@include oTypographySerifDisplayBoldSize($level);
-	@include oTypographyProgressiveFont('serif-display', 'bold');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('serif-display', 'bold');
+	} else {
+		font-family: $o-typography-serif-display;
+	}
 	font-weight: oFontsWeight(bold);
 }
 
@@ -354,9 +394,13 @@
 ///
 /// @requires {mixin} oTypographySerifDisplayItalicSize
 ///
-@mixin oTypographySerifDisplayItalic($level) {
+@mixin oTypographySerifDisplayItalic($level, $load-progressively: false) {
 	@include oTypographySerifDisplayItalicSize($level);
-	@include oTypographyProgressiveFont('serif-display', 'light');
+	@if $load-progressively {
+		@include oTypographyProgressiveFont('serif-display', 'light');
+	} else {
+		font-family: $o-typography-serif-display;
+	}
 	font-style: italic;
 	font-weight: oFontsWeight(light);
 }

--- a/scss/_type_matrix.scss
+++ b/scss/_type_matrix.scss
@@ -9,11 +9,13 @@
 /// Adjust size of sans
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySansSize(xl);
+///  @include oTypographySansSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -31,11 +33,14 @@
 /// Adjust the font to sans and set the size / line-height
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySans(xl);
+///  @include oTypographySans(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySansSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySans($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -51,11 +56,13 @@
 /// Adjust size of sansBold
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySansBoldSize(xl);
+///  @include oTypographySansBoldSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -71,13 +78,14 @@
 
 ///
 /// Adjust the font to sansBold and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySansBold(xl);
+///  @include oTypographySansBold(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySansBoldSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySansBold($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -93,11 +101,13 @@
 /// Adjust size of sansData
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySansDataSize(xl);
+///  @include oTypographySansDataSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -113,13 +123,14 @@
 
 ///
 /// Adjust the font to sansData and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySansData(xl);
+///  @include oTypographySansData(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySansDataSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySansData($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -135,11 +146,13 @@
 /// Adjust size of sansDataBold
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySansDataBoldSize(xl);
+///  @include oTypographySansDataBoldSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -155,13 +168,14 @@
 
 ///
 /// Adjust the font to sansDataBold and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySansDataBold(xl);
+///  @include oTypographySansDataBold(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySansDataBoldSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySansDataBold($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -177,11 +191,13 @@
 /// Adjust size of sansDataItalic
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySansDataItalicSize(xl);
+///  @include oTypographySansDataItalicSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -197,13 +213,14 @@
 
 ///
 /// Adjust the font to sansDataItalic and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySansDataItalic(xl);
+///  @include oTypographySansDataItalic(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySansDataItalicSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySansDataItalic($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -221,11 +238,13 @@
 /// Adjust size of serif
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySerifSize(xl);
+///  @include oTypographySerifSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -241,13 +260,14 @@
 
 ///
 /// Adjust the font to serif and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySerif(xl);
+///  @include oTypographySerif(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySerifSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySerif($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -263,11 +283,13 @@
 /// Adjust size of serifBold
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySerifBoldSize(xl);
+///  @include oTypographySerifBoldSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -283,13 +305,14 @@
 
 ///
 /// Adjust the font to serifBold and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySerifBold(xl);
+///  @include oTypographySerifBold(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySerifBoldSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySerifBold($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -305,11 +328,13 @@
 /// Adjust size of serifItalic
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySerifItalicSize(xl);
+///  @include oTypographySerifItalicSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -325,13 +350,14 @@
 
 ///
 /// Adjust the font to serifItalic and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySerifItalic(xl);
+///  @include oTypographySerifItalic(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySerifItalicSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySerifItalic($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -348,11 +374,13 @@
 /// Adjust size of serifDisplay
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySerifDisplaySize(xl);
+///  @include oTypographySerifDisplaySize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -368,13 +396,14 @@
 
 ///
 /// Adjust the font to serifDisplay and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySerifDisplay(xl);
+///  @include oTypographySerifDisplay(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySerifDisplaySize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySerifDisplay($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -390,11 +419,13 @@
 /// Adjust size of serifDisplayBold
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySerifDisplayBoldSize(xl);
+///  @include oTypographySerifDisplayBoldSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -410,13 +441,14 @@
 
 ///
 /// Adjust the font to serifDisplayBold and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySerifDisplayBold(xl);
+///  @include oTypographySerifDisplayBold(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySerifDisplayBoldSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySerifDisplayBold($level, $load-progressively: false) {
 	@if $load-progressively {
@@ -432,11 +464,13 @@
 /// Adjust size of serifDisplayItalic
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
-///  @include oTypographySerifDisplayItalicSize(xl);
+///  @include oTypographySerifDisplayItalicSize(xl, $with-progressive-size: true);
 ///
-/// @requires {mixin} font-size
+/// @requires {mixin} oTypographyFallbackFontSize
+/// @requires {function} convert-to-px
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
@@ -452,13 +486,14 @@
 
 ///
 /// Adjust the font to serifDisplayItalic and set the size / line-height
-///
-/// @param {String} $level - Accepts xl, l, m, s, xs
+/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
-///  @include oTypographySerifDisplayItalic(xl);
+///  @include oTypographySerifDisplayItalic(xl, $load-progressively: true);
 ///
 /// @requires {mixin} oTypographySerifDisplayItalicSize
+/// @requires {mixin} oTypographyProgressiveFont
+/// @requires {mixin} oFontsWeight
 ///
 @mixin oTypographySerifDisplayItalic($level, $load-progressively: false) {
 	@if $load-progressively {

--- a/scss/_type_matrix.scss
+++ b/scss/_type_matrix.scss
@@ -35,7 +35,7 @@
 	@include oTypographySansSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('sans', 'light');
-	} else {
+	} @else {
 		font-family: $o-typography-sans;
 	}
 	font-weight: oFontsWeight(light);
@@ -71,7 +71,7 @@
 	@include oTypographySansBoldSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('sans', 'semibold');
-	} else {
+	} @else {
 		font-family: $o-typography-sans;
 	}
 	font-weight: oFontsWeight(semibold);
@@ -107,7 +107,7 @@
 	@include oTypographySansDataSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('sans', 'regular');
-	} else {
+	} @else {
 		font-family: $o-typography-sans;
 	}
 	font-weight: oFontsWeight(regular);
@@ -143,7 +143,7 @@
 	@include oTypographySansDataBoldSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('sans', 'semibold');
-	} else {
+	} @else {
 		font-family: $o-typography-sans;
 	}
 	font-weight: oFontsWeight(semibold);
@@ -179,7 +179,7 @@
 	@include oTypographySansDataItalicSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('sans', 'regular');
-	} else {
+	} @else {
 		font-family: $o-typography-sans;
 	}
 	font-weight: oFontsWeight(regular);
@@ -217,7 +217,7 @@
 	@include oTypographySerifSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('serif', 'regular');
-	} else {
+	} @else {
 		font-family: $o-typography-serif;
 	}
 	font-weight: oFontsWeight(regular);
@@ -253,7 +253,7 @@
 	@include oTypographySerifBoldSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('serif', 'bold');
-	} else {
+	} @else {
 		font-family: $o-typography-serif;
 	}
 	font-weight: oFontsWeight(bold);
@@ -289,7 +289,7 @@
 	@include oTypographySerifItalicSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('serif', 'light');
-	} else {
+	} @else {
 		font-family: $o-typography-serif;
 	}
 	font-style: italic;
@@ -326,7 +326,7 @@
 	@include oTypographySerifDisplaySize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('serif-display', 'regular');
-	} else {
+	} @else {
 		font-family: $o-typography-serif-display;
 	}
 	font-weight: oFontsWeight(regular);
@@ -362,7 +362,7 @@
 	@include oTypographySerifDisplayBoldSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('serif-display', 'bold');
-	} else {
+	} @else {
 		font-family: $o-typography-serif-display;
 	}
 	font-weight: oFontsWeight(bold);
@@ -398,7 +398,7 @@
 	@include oTypographySerifDisplayItalicSize($level);
 	@if $load-progressively {
 		@include oTypographyProgressiveFont('serif-display', 'light');
-	} else {
+	} @else {
 		font-family: $o-typography-serif-display;
 	}
 	font-style: italic;

--- a/scss/_type_matrix.scss
+++ b/scss/_type_matrix.scss
@@ -15,7 +15,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySansSize($level) {
 	@include font-size(get-font-size(sans, $level), get-line-height(sans, $level));
@@ -33,7 +33,7 @@
 ///
 @mixin oTypographySans($level) {
 	@include oTypographySansSize($level);
-	font-family: $o-typography-sans;
+	@include oTypographyProgressiveFont('sans', 'light');
 	font-weight: oFontsWeight(light);
 }
 
@@ -47,7 +47,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySansBoldSize($level) {
 	@include font-size(get-font-size(sansBold, $level), get-line-height(sansBold, $level));
@@ -65,7 +65,7 @@
 ///
 @mixin oTypographySansBold($level) {
 	@include oTypographySansBoldSize($level);
-	font-family: $o-typography-sans;
+	@include oTypographyProgressiveFont('sans', 'semibold');
 	font-weight: oFontsWeight(semibold);
 }
 
@@ -79,7 +79,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySansDataSize($level) {
 	@include font-size(get-font-size(sansData, $level), get-line-height(sansData, $level));
@@ -97,7 +97,7 @@
 ///
 @mixin oTypographySansData($level) {
 	@include oTypographySansDataSize($level);
-	font-family: $o-typography-sans;
+	@include oTypographyProgressiveFont('sans', 'regular');
 	font-weight: oFontsWeight(regular);
 }
 
@@ -111,7 +111,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySansDataBoldSize($level) {
 	@include font-size(get-font-size(sansDataBold, $level), get-line-height(sansDataBold, $level));
@@ -129,7 +129,7 @@
 ///
 @mixin oTypographySansDataBold($level) {
 	@include oTypographySansDataBoldSize($level);
-	font-family: $o-typography-sans;
+	@include oTypographyProgressiveFont('sans', 'semibold');
 	font-weight: oFontsWeight(semibold);
 }
 
@@ -143,7 +143,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySansDataItalicSize($level) {
 	@include font-size(get-font-size(sansDataItalic, $level), get-line-height(sansDataItalic, $level));
@@ -161,7 +161,7 @@
 ///
 @mixin oTypographySansDataItalic($level) {
 	@include oTypographySansDataItalicSize($level);
-	font-family: $o-typography-sans;
+	@include oTypographyProgressiveFont('sans', 'regular');
 	font-weight: oFontsWeight(regular);
 	font-style: italic;
 }
@@ -177,7 +177,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySerifSize($level) {
 	@include font-size(get-font-size(serif, $level), get-line-height(serif, $level));
@@ -195,7 +195,7 @@
 ///
 @mixin oTypographySerif($level) {
 	@include oTypographySerifSize($level);
-	font-family: $o-typography-serif;
+	@include oTypographyProgressiveFont('serif', 'regular');
 	font-weight: oFontsWeight(regular);
 }
 
@@ -209,7 +209,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySerifBoldSize($level) {
 	@include font-size(get-font-size(serifBold, $level), get-line-height(serifBold, $level));
@@ -227,7 +227,7 @@
 ///
 @mixin oTypographySerifBold($level) {
 	@include oTypographySerifBoldSize($level);
-	font-family: $o-typography-serif;
+	@include oTypographyProgressiveFont('serif', 'bold');
 	font-weight: oFontsWeight(bold);
 }
 
@@ -241,7 +241,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySerifItalicSize($level) {
 	@include font-size(get-font-size(serifItalic, $level), get-line-height(serifItalic, $level));
@@ -259,7 +259,7 @@
 ///
 @mixin oTypographySerifItalic($level) {
 	@include oTypographySerifItalicSize($level);
-	font-family: $o-typography-serif;
+	@include oTypographyProgressiveFont('serif', 'light');
 	font-style: italic;
 	font-weight: oFontsWeight(light);
 }
@@ -274,7 +274,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySerifDisplaySize($level) {
 	@include font-size(get-font-size(serifDisplay, $level), get-line-height(serifDisplay, $level));
@@ -292,7 +292,7 @@
 ///
 @mixin oTypographySerifDisplay($level) {
 	@include oTypographySerifDisplaySize($level);
-	font-family: $o-typography-serif-display;
+	@include oTypographyProgressiveFont('serif-display', 'regular');
 	font-weight: oFontsWeight(regular);
 }
 
@@ -306,7 +306,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySerifDisplayBoldSize($level) {
 	@include font-size(get-font-size(serifDisplayBold, $level), get-line-height(serifDisplayBold, $level));
@@ -324,7 +324,7 @@
 ///
 @mixin oTypographySerifDisplayBold($level) {
 	@include oTypographySerifDisplayBoldSize($level);
-	font-family: $o-typography-serif-display;
+	@include oTypographyProgressiveFont('serif-display', 'bold');
 	font-weight: oFontsWeight(bold);
 }
 
@@ -338,7 +338,7 @@
 ///
 /// @requires {mixin} font-size
 /// @requires {function} get-font-size
-/// @requires {function} get-line-height 
+/// @requires {function} get-line-height
 ///
 @mixin oTypographySerifDisplayItalicSize($level) {
 	@include font-size(get-font-size(serifDisplayItalic, $level), get-line-height(serifDisplayItalic, $level));
@@ -356,7 +356,7 @@
 ///
 @mixin oTypographySerifDisplayItalic($level) {
 	@include oTypographySerifDisplayItalicSize($level);
-	font-family: $o-typography-serif-display;
+	@include oTypographyProgressiveFont('serif-display', 'light');
 	font-style: italic;
 	font-weight: oFontsWeight(light);
 }

--- a/scss/_type_matrix.scss
+++ b/scss/_type_matrix.scss
@@ -17,8 +17,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySansSize($level) {
-	@include font-size(get-font-size(sans, $level), get-line-height(sans, $level));
+@mixin oTypographySansSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(sans, $level));
+	line-height: convert-to-px(get-line-height(sans, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(sans, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -53,8 +59,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySansBoldSize($level) {
-	@include font-size(get-font-size(sansBold, $level), get-line-height(sansBold, $level));
+@mixin oTypographySansBoldSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(sansBold, $level));
+	line-height: convert-to-px(get-line-height(sansBold, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(sansBold, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -89,8 +101,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySansDataSize($level) {
-	@include font-size(get-font-size(sansData, $level), get-line-height(sansData, $level));
+@mixin oTypographySansDataSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(sansData, $level));
+	line-height: convert-to-px(get-line-height(sansData, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(sansData, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -125,8 +143,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySansDataBoldSize($level) {
-	@include font-size(get-font-size(sansDataBold, $level), get-line-height(sansDataBold, $level));
+@mixin oTypographySansDataBoldSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(sansDataBold, $level));
+	line-height: convert-to-px(get-line-height(sansDataBold, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(sansDataBold, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -161,8 +185,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySansDataItalicSize($level) {
-	@include font-size(get-font-size(sansDataItalic, $level), get-line-height(sansDataItalic, $level));
+@mixin oTypographySansDataItalicSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(sansDataItalic, $level));
+	line-height: convert-to-px(get-line-height(sansDataItalic, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(sansDataItalic, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -199,8 +229,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySerifSize($level) {
-	@include font-size(get-font-size(serif, $level), get-line-height(serif, $level));
+@mixin oTypographySerifSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(serif, $level));
+	line-height: convert-to-px(get-line-height(serif, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(serif, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -235,8 +271,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySerifBoldSize($level) {
-	@include font-size(get-font-size(serifBold, $level), get-line-height(serifBold, $level));
+@mixin oTypographySerifBoldSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(serifBold, $level));
+	line-height: convert-to-px(get-line-height(serifBold, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(serifBold, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -271,8 +313,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySerifItalicSize($level) {
-	@include font-size(get-font-size(serifItalic, $level), get-line-height(serifItalic, $level));
+@mixin oTypographySerifItalicSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(serifItalic, $level));
+	line-height: convert-to-px(get-line-height(serifItalic, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(serifItalic, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -308,8 +356,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySerifDisplaySize($level) {
-	@include font-size(get-font-size(serifDisplay, $level), get-line-height(serifDisplay, $level));
+@mixin oTypographySerifDisplaySize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(serifDisplay, $level));
+	line-height: convert-to-px(get-line-height(serifDisplay, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(serifDisplay, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -344,8 +398,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySerifDisplayBoldSize($level) {
-	@include font-size(get-font-size(serifDisplayBold, $level), get-line-height(serifDisplayBold, $level));
+@mixin oTypographySerifDisplayBoldSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(serifDisplayBold, $level));
+	line-height: convert-to-px(get-line-height(serifDisplayBold, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(serifDisplayBold, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///
@@ -380,8 +440,14 @@
 /// @requires {function} get-font-size
 /// @requires {function} get-line-height
 ///
-@mixin oTypographySerifDisplayItalicSize($level) {
-	@include font-size(get-font-size(serifDisplayItalic, $level), get-line-height(serifDisplayItalic, $level));
+@mixin oTypographySerifDisplayItalicSize($level, $with-progressive-size: false) {
+	$font-size: convert-to-px(get-font-size(serifDisplayItalic, $level));
+	line-height: convert-to-px(get-line-height(serifDisplayItalic, $level));
+	@if $with-progressive-size {
+		@include oTypographyFallbackFontSize(serifDisplayItalic, $font-size);
+	} @else {
+		font-size: $font-size;
+	}
 }
 
 ///

--- a/scss/_type_matrix.scss
+++ b/scss/_type_matrix.scss
@@ -9,7 +9,7 @@
 /// Adjust size of sans
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySansSize(xl, $with-progressive-size: true);
@@ -33,7 +33,7 @@
 /// Adjust the font to sans and set the size / line-height
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySans(xl, $load-progressively: true);
@@ -56,7 +56,7 @@
 /// Adjust size of sansBold
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySansBoldSize(xl, $with-progressive-size: true);
@@ -78,7 +78,7 @@
 
 ///
 /// Adjust the font to sansBold and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySansBold(xl, $load-progressively: true);
@@ -101,7 +101,7 @@
 /// Adjust size of sansData
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySansDataSize(xl, $with-progressive-size: true);
@@ -123,7 +123,7 @@
 
 ///
 /// Adjust the font to sansData and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySansData(xl, $load-progressively: true);
@@ -146,7 +146,7 @@
 /// Adjust size of sansDataBold
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySansDataBoldSize(xl, $with-progressive-size: true);
@@ -168,7 +168,7 @@
 
 ///
 /// Adjust the font to sansDataBold and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySansDataBold(xl, $load-progressively: true);
@@ -191,7 +191,7 @@
 /// Adjust size of sansDataItalic
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySansDataItalicSize(xl, $with-progressive-size: true);
@@ -213,7 +213,7 @@
 
 ///
 /// Adjust the font to sansDataItalic and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySansDataItalic(xl, $load-progressively: true);
@@ -238,7 +238,7 @@
 /// Adjust size of serif
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySerifSize(xl, $with-progressive-size: true);
@@ -260,7 +260,7 @@
 
 ///
 /// Adjust the font to serif and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySerif(xl, $load-progressively: true);
@@ -283,7 +283,7 @@
 /// Adjust size of serifBold
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySerifBoldSize(xl, $with-progressive-size: true);
@@ -305,7 +305,7 @@
 
 ///
 /// Adjust the font to serifBold and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySerifBold(xl, $load-progressively: true);
@@ -328,7 +328,7 @@
 /// Adjust size of serifItalic
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySerifItalicSize(xl, $with-progressive-size: true);
@@ -350,7 +350,7 @@
 
 ///
 /// Adjust the font to serifItalic and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySerifItalic(xl, $load-progressively: true);
@@ -374,7 +374,7 @@
 /// Adjust size of serifDisplay
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySerifDisplaySize(xl, $with-progressive-size: true);
@@ -396,7 +396,7 @@
 
 ///
 /// Adjust the font to serifDisplay and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySerifDisplay(xl, $load-progressively: true);
@@ -419,7 +419,7 @@
 /// Adjust size of serifDisplayBold
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySerifDisplayBoldSize(xl, $with-progressive-size: true);
@@ -441,7 +441,7 @@
 
 ///
 /// Adjust the font to serifDisplayBold and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySerifDisplayBold(xl, $load-progressively: true);
@@ -464,7 +464,7 @@
 /// Adjust size of serifDisplayItalic
 ///
 /// @param {String} $level - Accepts xl, l, m, s, xs
-/// @param {Boolean} $with-progressive-size [false] - Should it output the fallback font's scaled size
+/// @param {Bool} $with-progressive-size [false] - Should it output the fallback font's scaled size
 ///
 /// @example
 ///  @include oTypographySerifDisplayItalicSize(xl, $with-progressive-size: true);
@@ -486,7 +486,7 @@
 
 ///
 /// Adjust the font to serifDisplayItalic and set the size / line-height
-/// @param {Boolean} $load-progressively [false] - Should it load the font progressively
+/// @param {Bool} $load-progressively [false] - Should it load the font progressively
 ///
 /// @example
 ///  @include oTypographySerifDisplayItalic(xl, $load-progressively: true);

--- a/scss/_type_matrix.scss
+++ b/scss/_type_matrix.scss
@@ -32,11 +32,11 @@
 /// @requires {mixin} oTypographySansSize
 ///
 @mixin oTypographySans($level, $load-progressively: false) {
-	@include oTypographySansSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('sans', 'light');
+		@include oTypographyProgressiveFont(sans, $level);
 	} @else {
 		font-family: $o-typography-sans;
+		@include oTypographySansSize($level);
 	}
 	font-weight: oFontsWeight(light);
 }
@@ -68,11 +68,11 @@
 /// @requires {mixin} oTypographySansBoldSize
 ///
 @mixin oTypographySansBold($level, $load-progressively: false) {
-	@include oTypographySansBoldSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('sans', 'semibold');
+		@include oTypographyProgressiveFont(sansBold, $level);
 	} @else {
 		font-family: $o-typography-sans;
+		@include oTypographySansBoldSize($level);
 	}
 	font-weight: oFontsWeight(semibold);
 }
@@ -104,11 +104,11 @@
 /// @requires {mixin} oTypographySansDataSize
 ///
 @mixin oTypographySansData($level, $load-progressively: false) {
-	@include oTypographySansDataSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('sans', 'regular');
+		@include oTypographyProgressiveFont(sansData, $level);
 	} @else {
 		font-family: $o-typography-sans;
+		@include oTypographySansDataSize($level);
 	}
 	font-weight: oFontsWeight(regular);
 }
@@ -140,11 +140,11 @@
 /// @requires {mixin} oTypographySansDataBoldSize
 ///
 @mixin oTypographySansDataBold($level, $load-progressively: false) {
-	@include oTypographySansDataBoldSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('sans', 'semibold');
+		@include oTypographyProgressiveFont(sansDataBold, $level);
 	} @else {
 		font-family: $o-typography-sans;
+		@include oTypographySansDataBoldSize($level);
 	}
 	font-weight: oFontsWeight(semibold);
 }
@@ -176,11 +176,11 @@
 /// @requires {mixin} oTypographySansDataItalicSize
 ///
 @mixin oTypographySansDataItalic($level, $load-progressively: false) {
-	@include oTypographySansDataItalicSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('sans', 'regular');
+		@include oTypographyProgressiveFont(sansDataItalic, $level);
 	} @else {
 		font-family: $o-typography-sans;
+		@include oTypographySansDataItalicSize($level);
 	}
 	font-weight: oFontsWeight(regular);
 	font-style: italic;
@@ -214,11 +214,11 @@
 /// @requires {mixin} oTypographySerifSize
 ///
 @mixin oTypographySerif($level, $load-progressively: false) {
-	@include oTypographySerifSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('serif', 'regular');
+		@include oTypographyProgressiveFont(serif, $level);
 	} @else {
 		font-family: $o-typography-serif;
+		@include oTypographySerifSize($level);
 	}
 	font-weight: oFontsWeight(regular);
 }
@@ -250,11 +250,11 @@
 /// @requires {mixin} oTypographySerifBoldSize
 ///
 @mixin oTypographySerifBold($level, $load-progressively: false) {
-	@include oTypographySerifBoldSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('serif', 'bold');
+		@include oTypographyProgressiveFont(serifBold, $level);
 	} @else {
 		font-family: $o-typography-serif;
+		@include oTypographySerifBoldSize($level);
 	}
 	font-weight: oFontsWeight(bold);
 }
@@ -286,11 +286,11 @@
 /// @requires {mixin} oTypographySerifItalicSize
 ///
 @mixin oTypographySerifItalic($level, $load-progressively: false) {
-	@include oTypographySerifItalicSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('serif', 'light');
+		@include oTypographyProgressiveFont(serifItalic, $level);
 	} @else {
 		font-family: $o-typography-serif;
+		@include oTypographySerifItalicSize($level);
 	}
 	font-style: italic;
 	font-weight: oFontsWeight(light);
@@ -323,11 +323,11 @@
 /// @requires {mixin} oTypographySerifDisplaySize
 ///
 @mixin oTypographySerifDisplay($level, $load-progressively: false) {
-	@include oTypographySerifDisplaySize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('serif-display', 'regular');
+		@include oTypographyProgressiveFont(serifDisplay, $level);
 	} @else {
 		font-family: $o-typography-serif-display;
+		@include oTypographySerifDisplaySize($level);
 	}
 	font-weight: oFontsWeight(regular);
 }
@@ -359,11 +359,11 @@
 /// @requires {mixin} oTypographySerifDisplayBoldSize
 ///
 @mixin oTypographySerifDisplayBold($level, $load-progressively: false) {
-	@include oTypographySerifDisplayBoldSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('serif-display', 'bold');
+		@include oTypographyProgressiveFont(serifDisplayBold, $level);
 	} @else {
 		font-family: $o-typography-serif-display;
+		@include oTypographySerifDisplayBoldSize($level);
 	}
 	font-weight: oFontsWeight(bold);
 }
@@ -395,11 +395,11 @@
 /// @requires {mixin} oTypographySerifDisplayItalicSize
 ///
 @mixin oTypographySerifDisplayItalic($level, $load-progressively: false) {
-	@include oTypographySerifDisplayItalicSize($level);
 	@if $load-progressively {
-		@include oTypographyProgressiveFont('serif-display', 'light');
+		@include oTypographyProgressiveFont(serifDisplayItalic, $level);
 	} @else {
 		font-family: $o-typography-serif-display;
+		@include oTypographySerifDisplayItalicSize($level);
 	}
 	font-style: italic;
 	font-weight: oFontsWeight(light);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -99,8 +99,8 @@ $o-typography-font-scale: (
 //
 // $o-typography-progressive-fonts: (
 //   serif: ('light'),
-//    serif-display: ('regular'),
-// 	  sans: ('regular' 'semibold')
+//   serif-display: ('regular'),
+// 	 sans: ('regular' 'semibold')
 // );
 $o-typography-progressive-fonts: () !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -101,6 +101,10 @@ $o-typography-font-scale: (
 //
 $o-typography-progressive-fonts: () !default;
 
+// Sets the prefix used for the 'web fonts loaded' class
+//
+$o-typography-loaded-prefix: 'o-typography-loaded' !default;
+
 // Previously, $o-typography-font-scale was called $font-scale. In order to not
 // make this rename a breaking change, check if anything is overriding
 // $font-scale and if it is, set $o-typography-font-scale to that value.

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -95,15 +95,13 @@ $o-typography-font-scale: (
 	)
 );
 
-/**
- * Configure which fonts/weights are progressively loaded, e.g.
- *
- * $o-typography-progressive-fonts: (
- *   serif: ('light'),
- *   serif-display: ('regular'),
- * 	 sans: ('regular' 'semibold')
- * );
- */
+// Configure which fonts/weights are progressively loaded, e.g.
+//
+// $o-typography-progressive-fonts: (
+//   serif: ('light'),
+//    serif-display: ('regular'),
+// 	  sans: ('regular' 'semibold')
+// );
 $o-typography-progressive-fonts: () !default;
 
 // Previously, $o-typography-font-scale was called $font-scale. In order to not

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -95,13 +95,10 @@ $o-typography-font-scale: (
 	)
 );
 
-// Configure which fonts/weights are progressively loaded, e.g.
+// Configure which fonts are progressively loaded, e.g.
 //
-// $o-typography-progressive-fonts: (
-//   serif: ('light'),
-//   serif-display: ('regular'),
-//   sans: ('regular' 'semibold')
-// );
+// $o-typography-progressive-fonts: serifDisplay, sans, sansData, sansDataBold;
+//
 $o-typography-progressive-fonts: () !default;
 
 // Previously, $o-typography-font-scale was called $font-scale. In order to not

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -95,15 +95,20 @@ $o-typography-font-scale: (
 	)
 );
 
-// Configure which fonts are progressively loaded, e.g.
 //
+// Configure which fonts are progressively loaded, e.g.
 // $o-typography-progressive-fonts: serifDisplay, sans, sansData, sansDataBold;
+//
+// @type List
 //
 $o-typography-progressive-fonts: () !default;
 
+//
 // Sets the prefix used for the 'web fonts loaded' class
 //
-$o-typography-loaded-prefix: 'o-typography-loaded' !default;
+// @type String
+//
+$o-typography-loaded-prefix: 'o-typography--loaded' !default;
 
 // Previously, $o-typography-font-scale was called $font-scale. In order to not
 // make this rename a breaking change, check if anything is overriding

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -95,6 +95,17 @@ $o-typography-font-scale: (
 	)
 );
 
+/**
+ * Configure which fonts/weights are progressively loaded, e.g.
+ *
+ * $o-typography-progressive-fonts: (
+ *   serif: ('light'),
+ *   serif-display: ('regular'),
+ * 	 sans: ('regular' 'semibold')
+ * );
+ */
+$o-typography-progressive-fonts: () !default;
+
 // Previously, $o-typography-font-scale was called $font-scale. In order to not
 // make this rename a breaking change, check if anything is overriding
 // $font-scale and if it is, set $o-typography-font-scale to that value.

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -100,7 +100,7 @@ $o-typography-font-scale: (
 // $o-typography-progressive-fonts: (
 //   serif: ('light'),
 //   serif-display: ('regular'),
-// 	 sans: ('regular' 'semibold')
+//   sans: ('regular' 'semibold')
 // );
 $o-typography-progressive-fonts: () !default;
 


### PR DESCRIPTION
A major annoyance with webfonts is the FOIT while the font is loading.
This adds functionality of depending on a certain class existing further up the dom (e.g. on the `html`) before setting the font on an element. Coupled with some sort of `FontFaceObserver` pattern (i.e. only add the class once the font is loaded), this will eliminate the FOIT

Also does some scaling of the size of the fallback font to match the webfont

e.g.

```
.foo {
    @include oTypographySerifDisplay(m, $load-progressively: true);
}
```

=>

```
.foo {
    font-family: serif;
    font-size: 18px;
    line-height: 24px;
    font-weight: 400;
}
.loaded-SerifDisplay .foo {
    font-family: FinancierDisplayWeb,serif;
    font-size: 20px;
}
```

```
.foo {
    @include oTypographySerifDisplaySize(m, $with-progressive-size: true);
}
```

=>

```
.foo {
    font-size: 18px;
    line-height: 24px;
}
.loaded-SerifDisplay .foo {
    font-size: 20px;
}
```

@keirog 