### PR TITLE
Revert 70 revert 67 migrate from n content body

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sans or SansBold are the common fonts for the site. SansData, SansDataBold and S
 <th>Sans</th>
 <th>SansBold</th>
 <th>SansData</th>
-<th>SansDataBlod</th>
+<th>SansDataBold</th>
 <th>SansDataItalic</th>
 </tr>
 </thead><tbody>
@@ -195,8 +195,8 @@ The classes do not depend on any specific HTML element, but appropriate semantic
 
 See the [demos](http://registry.origami.ft.com/components/o-typography) for a full list of the classes provided and their effects.
 
-#### Wrapper
-In addition to applying classes individual to elements, body styles can be applied to an HTML element and descendent `h2, h3, p, a, strong, em, small, sup, sub, ul, ol, li` elements will have styling applied.
+#### Wrappers
+In addition to applying classes individual to elements, body styles can be applied to an HTML element and descendent `h2, h3, h4, p, a, blockquote, footer, aside, strong, em, small, sup, sub, ul, ol, li` elements will have typographic styling applied.
 
 ```html
 <div class="o-typography-body-wrapper">
@@ -206,6 +206,20 @@ In addition to applying classes individual to elements, body styles can be appli
 	<p>Body block with <em>styled inline text</em>.</p>
 </div>
 ```
+
+```html
+<aside class="o-typography-aside-wrapper">
+	<h3>Aside Title</h3>
+	<article>
+		<h4><a>Example Headline</a></h4>
+	</article>
+	<div>
+		<p>Some explanatory text would go here</p>
+	</div>
+</aside>
+```
+
+More detailed examples of the wrappers can be found in the demos.
 
 Pre-defined classes are not available to module developers. Module developers are required to use the mixins.
 
@@ -217,18 +231,18 @@ If you don't want to include the pre-defined classes in your HTML (or are a modu
 
 The font system is a matrix which defines small building blocks that can used as a base for typographic elements. Having a small subset of sizes and styles allows for greater consistency.
 
-Type name          | Standard mixin                                  | Size/Line-height only mixin
+Type name					| Standard mixin																	| Size/Line-height only mixin
 -------------------| ----------------------------------------------- | -----------------------------------
-Sans               | `@include oTypographySans([xl-xs])`               | `@include oTypographySansSize([xl-xs])`
-SansBold           | `@include oTypographySansBold([xl-xs])`           | `@include oTypographySansBoldSize([xl-xs])`
-SansData           | `@include oTypographySansData([xl-xs])`           | `@include oTypographySansDataSize([xl-xs])`
-SansDataBold       | `@include oTypographySansDataBold([xl-xs])`       | `@include oTypographySansDataBoldSize([xl-xs])`
-SansDataItalic     | `@include oTypographySansDataItalic([xl-xs])`     | `@include oTypographySansDataItalicSize([xl-xs])`
-Serif              | `@include oTypographySerif([xl-xs])`              | `@include oTypographySerifSize([xl-xs])`
-SerifBold          | `@include oTypographySerifBold([xl-xs])`          | `@include oTypographySerifBoldSize([xl-xs])`
-SerifItalic        | `@include oTypographySerifItalic([xl-xs])`        | `@include oTypographySerifItalicSize([xl-xs])`
-SerifDisplay       | `@include oTypographySerifDisplay([xl-xs])`       | `@include oTypographySerifDisplaySize([xl-xs])`
-SerifDisplayBold   | `@include oTypographySerifDisplayBold([xl-xs])`   | `@include oTypographySerifDisplayBoldSize([xl-xs])`
+Sans							 | `@include oTypographySans([xl-xs])`							 | `@include oTypographySansSize([xl-xs])`
+SansBold					 | `@include oTypographySansBold([xl-xs])`					 | `@include oTypographySansBoldSize([xl-xs])`
+SansData					 | `@include oTypographySansData([xl-xs])`					 | `@include oTypographySansDataSize([xl-xs])`
+SansDataBold			 | `@include oTypographySansDataBold([xl-xs])`			 | `@include oTypographySansDataBoldSize([xl-xs])`
+SansDataItalic		 | `@include oTypographySansDataItalic([xl-xs])`		 | `@include oTypographySansDataItalicSize([xl-xs])`
+Serif							| `@include oTypographySerif([xl-xs])`							| `@include oTypographySerifSize([xl-xs])`
+SerifBold					| `@include oTypographySerifBold([xl-xs])`					| `@include oTypographySerifBoldSize([xl-xs])`
+SerifItalic				| `@include oTypographySerifItalic([xl-xs])`				| `@include oTypographySerifItalicSize([xl-xs])`
+SerifDisplay			 | `@include oTypographySerifDisplay([xl-xs])`			 | `@include oTypographySerifDisplaySize([xl-xs])`
+SerifDisplayBold	 | `@include oTypographySerifDisplayBold([xl-xs])`	 | `@include oTypographySerifDisplayBoldSize([xl-xs])`
 SerifDisplayItalic | `@include oTypographySerifDisplayItalic([xl-xs])` | `@include oTypographySerifDisplayItalicSize([xl-xs])`
 
 Example, using the font system in Sass
@@ -290,11 +304,11 @@ One of the drawbacks of using web fonts is some browsers hide the text while the
 
 ```
 .text {
-    font-family: serif;
+	font-family: serif;
 }
 
 .font-loaded-serif .text {
-    font-family: FinancierDisplayWeb,serif;
+	font-family: FinancierDisplayWeb,serif;
 }
 ```
 
@@ -310,14 +324,14 @@ A further thing to note is the fallback fonts are generally of a different size 
 
 ```
 .text {
-    font-family: serif;
-    font-size: 18px;
-    line-height: 24px;
+	font-family: serif;
+	font-size: 18px;
+	line-height: 24px;
 }
 
 .font-loaded-serif .text {
-    font-family: FinancierDisplayWeb,serif;
-    font-size: 20px
+	font-family: FinancierDisplayWeb,serif;
+	font-size: 20px
 }
 ```
 
@@ -331,11 +345,11 @@ $o-typography-progressive-fonts: sansData, serifDisplay;
 $o-typography-loaded-prefix: 'loaded-font';
 
 .foo {
-    @include oTypographySansData(m, $load-progressively: true);
+	@include oTypographySansData(m, $load-progressively: true);
 }
 
 .bar {
-    @include oTypographySerifDisplayItalic(m, $load-progressively: true);
+	@include oTypographySerifDisplayItalic(m, $load-progressively: true);
 }
 ```
 
@@ -343,23 +357,23 @@ compiles to
 
 ```
 .foo {
-    font-family: sans-serif;
-    font-size: 12.18px;
-    line-height: 16px;
-    font-weight: 400;
+	font-family: sans-serif;
+	font-size: 12.18px;
+	line-height: 16px;
+	font-weight: 400;
 }
 
 .loaded-font-sansData .foo {
-    font-family: MetricWeb,sans-serif;
-    font-size: 14px;
+	font-family: MetricWeb,sans-serif;
+	font-size: 14px;
 }
 
 .bar {
-    font-family: FinancierDisplayWeb,serif;
-    font-size: 20px;
-    line-height: 22px;
-    font-style: italic;
-    font-weight: 200;
+	font-family: FinancierDisplayWeb,serif;
+	font-size: 20px;
+	line-height: 22px;
+	font-style: italic;
+	font-weight: 200;
 }
 ```
 

--- a/demos/src/article.mustache
+++ b/demos/src/article.mustache
@@ -1,7 +1,7 @@
 <article class="o-grid-row demo demo-article">
 	<div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
 		<div class="o-typography-flyline">
-			<a href="#" class="o-typography-flyline__link">Standard Chartered PLC</a>	
+			<a href="#" class="o-typography-flyline__link">Standard Chartered PLC</a>
 		</div>
 		<h1 class="o-typography-heading1">A ‘Rosetta stone’ that may unlock the mystery of life on Earth</h1>
 		<p class="o-typography-lead">Belgian-Brazilian brewer ups the stakes in beer takeover battle</p>
@@ -42,6 +42,7 @@
 			<hr />
 			<p class="o-typography-body"><em><strong>Letter in response to this article:</strong></em></p>
 			<p class="o-typography-body"><em><a class="o-typography-link" href="#void">Spending €1.4bn for the ‘Rosetta stone’ is a tragic misappropriation of resources / From J Antoni Rafalski</a></em></p>
+			<footer class="o-typography-footer">Footer such as copyright notice.</footer>
 		</div>
 	</div>
 </article>

--- a/demos/src/asides.mustache
+++ b/demos/src/asides.mustache
@@ -1,0 +1,41 @@
+<article class="o-grid-row demo demo-article">
+	<div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
+		<aside class="demo-article__body o-typography-aside-wrapper">
+			<h3>This is the aside title</h3>
+			<article>
+				<h4>
+					<a href="#">Headline link to another article</a>
+				</h4>
+			</article>
+			<div>
+				<p>Here's some content in the aside.</p>
+				<p>There could be a few paragraphs.</p>
+			</div>
+			<blockquote>
+				<p>Here's a blockquote that's pulled out into an aside</p>
+				<footer>This is who said it</footer>
+			</blockquote>
+		</aside>
+		<br>
+		<aside>
+			<div class="o-typography-big-number">222m</div>
+			<footer class="o-typography-footer o-typography-bold">This is quite a big number</footer>
+		</aside>
+		<br>
+		<aside>
+			<h3 class="o-typography-aside__title">This is the aside title - standard</h3>
+			<h3 class="o-typography-aside__title--large">This is the aside title - large</h3>
+			<br>
+			<article>
+				<h4 class="o-typography-aside__headline">Headline to another article no link - standard</h4>
+				<h4 class="o-typography-aside__headline--large">Headline to another article no link - large</h4>
+				<h4 class="o-typography-aside__headline--small">Headline to another article no link - small</h4>
+			</article>
+			<br>
+			<div>
+				<p class="o-typography-aside__body">Aside content in standard size.</p>
+				<p class="o-typography-aside__body--small">Aside content in small size.</p>
+			</div>
+		</aside>
+	</div>
+</article>

--- a/demos/src/body-wrapper.mustache
+++ b/demos/src/body-wrapper.mustache
@@ -3,7 +3,7 @@
 		<div class="demo-article__body o-typography-body-wrapper">
 			<p>3<sup>rd</sup> h<sub>2</sub>o <strong>Anheuser-Busch</strong> <em>InBev</em> raised its proposed takeover offer for SABMiller to £43.50 a share <small>on Monday</small>, upping the stakes in a takeover battle to create the world’s dominant brewing company, according to people familiar with the latest bid.</p>
 			<p>News of the fourth proposal by <a href="#">AB InBev</a> for its London-listed rival, which values SABMiller’s equity at $70bn, came with less than 52 hours before a UK bid deadline.</p>
-			<h2>Heading 2 Lorem ipsum dolor sit amet.</h2>
+			<h2>In Article Subhead Lorem ipsum dolor sit amet.</h2>
 			<p>Glencore has fired the starting gun on a sales process for two copper assets after the miner-cum-trader was approached by several suitors.</p>
 
 			<h3>Heading 3 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Numquam!</h3>
@@ -36,6 +36,7 @@
 			<hr />
 			<p><em><strong>Letter in response to this article:</strong></em></p>
 			<p><em><a href="#void">Spending €1.4bn for the ‘Rosetta stone’ is a tragic misappropriation of resources / From J Antoni Rafalski</a></em></p>
+			<footer>Footer such as copyright notice.</footer>
 		</div>
 	</div>
 </article>

--- a/demos/src/body.mustache
+++ b/demos/src/body.mustache
@@ -8,7 +8,7 @@
 			<p class="o-typography-body">Nemo, aspernatur. Quae delectus necessitatibus recusandae corporis, dolorem, molestiae vel pariatur, perspiciatis nisi in saepe non asperiores iure quo, blanditiis.</p>
 			<p class="o-typography-body">
 				Bold: <strong class="o-typography-bold">o-typography-bold</strong><br />
-				Italic: <em class="o-typography-italic">o-typography-italic</em><br /> 
+				Italic: <em class="o-typography-italic">o-typography-italic</em><br />
 				Superscript: <sup class="o-typography-sup">o-typography-sup</sup><br />
 				Subscript: <sub class="o-typography-sub">o-typography-sub</sub><br />
 			</p>
@@ -27,6 +27,7 @@
 				<li>Quo totam numquam, molestias consequatur.</li>
 				<li>Quasi libero fuga soluta quisquam!</li>
 			</ol>
+			<footer class="o-typography-footer">Footer such as copyright notice.</footer>
 		</div>
 	</div>
 </article>

--- a/demos/src/headings.mustache
+++ b/demos/src/headings.mustache
@@ -2,3 +2,5 @@
 <h2 class="o-typography-heading2">Heading 2</h2>
 <h3 class="o-typography-heading3">Heading 3</h3>
 <h3 class="o-typography-heading4">Heading 4</h3>
+<h2 class="o-typography-subhead">In Article Subheading</h2>
+<h2 class="o-typography-subhead--crosshead">In Article Crosshead</h2>

--- a/main.scss
+++ b/main.scss
@@ -7,15 +7,18 @@
 @import 'o-hoverable/main';
 @import 'o-fonts/main';
 
+@import "scss/color_use_cases";
 @import 'scss/helpers';
 @import 'scss/variables';
 @import 'scss/type_matrix';
 @import 'scss/progressive-font';
 
+@import 'scss/body_aside';
 @import 'scss/body_common';
 @import 'scss/body_general';
 @import 'scss/headings';
 
+@import 'scss/wrapped_aside';
 @import 'scss/wrapped_common';
 @import 'scss/wrapped_general';
 
@@ -37,6 +40,12 @@
 	}
 	.o-typography-heading5 {
 		@include oTypographyHeading5;
+	}
+	.o-typography-subhead {
+		@include oTypographySubhead;
+	}
+	.o-typography-subhead--crosshead {
+		@include oTypographySubheadCrosshead;
 	}
 
 	// Body copy - common
@@ -84,10 +93,45 @@
 	.o-typography-list--unordered {
 		@include oTypographyListUnordered;
 	}
+	.o-typography-footer {
+		@include oTypographyFooter;
+	}
+	.o-typography-blockquote {
+		@include oTypographyBlockquote;
+	}
+	.o-typography-big-number {
+		@include oTypographyBigNumber;
+	}
+	.o-typography-aside__title {
+		@include oTypographyAsideTitle;
+	}
+	.o-typography-aside__title--large {
+		@include oTypographyAsideTitleLarge;
+	}
+	.o-typography-aside__headline {
+		@include oTypographyAsideHeadline;
+	}
+	.o-typography-aside__headline--small {
+		@include oTypographyAsideHeadlineSmall;
+	}
+	.o-typography-aside__headline--large {
+		@include oTypographyAsideHeadlineLarge;
+	}
+	.o-typography-aside__body {
+		@include oTypographyAsideBody;
+	}
+	.o-typography-aside__body--small {
+		@include oTypographyAsideBodySmall;
+	}
 
 	// Body wrapper
 	.o-typography-body-wrapper {
 		@include oTypographyBodyWrapper;
+	}
+
+	// Aside wrapper
+	.o-typography-aside-wrapper {
+		@include oTypographyAsideWrapper;
 	}
 
 	// Don't output twice

--- a/origami.json
+++ b/origami.json
@@ -52,6 +52,12 @@
 			"template": "demos/src/manage-account.mustache",
 			"expanded": true,
 			"description": ""
+		},
+		{
+			"name": "asides",
+			"template": "demos/src/asides.mustache",
+			"expanded": true,
+			"description": ""
 		}
 	]
 }

--- a/scss/_body_aside.scss
+++ b/scss/_body_aside.scss
@@ -1,0 +1,81 @@
+/// Style for big-numbers
+@mixin oTypographyBigNumber {
+	@include oTypographySerifDisplay(xl);
+	@include oTypographyBold;
+	@include oColorsFor(o-typography-aside-text, text);
+	font-size: 3em;
+	line-height: 1em;
+}
+
+// Helper mixin to DRY out variants
+@mixin oTypographyAsideTitleBase {
+	@include oTypographyBold;
+	@include oColorsFor(o-typography-aside-text, text);
+	a {
+		@include oColorsFor(o-typography-aside-text, text);
+		border-bottom: 0;
+		text-decoration: none;
+	}
+}
+
+
+/// Style for <aside> title
+@mixin oTypographyAsideTitle {
+	@include oTypographyAsideTitleBase;
+	@include oTypographyHeading3;
+}
+
+/// Style for <aside> title large variant
+@mixin oTypographyAsideTitleLarge {
+	@include oTypographyAsideTitleBase;
+	@include oTypographyHeading2;
+}
+
+// Helper mixin to DRY out variants
+@mixin oTypographyAsideHeadlineBase {
+	@include oColorsFor(o-typography-aside-text, text);
+	word-wrap: break-word;
+	margin-top: 8px;
+	margin-bottom: 8px;
+	p {
+		margin: 0;
+	}
+}
+
+/// Style for <aside> headline
+@mixin oTypographyAsideHeadline {
+	@include oTypographyAsideHeadlineBase;
+	@include oTypographySerifDisplay(m);
+	font-size: 26px;
+	line-height: 27px;
+}
+
+/// Style for <aside> headline small variant
+@mixin oTypographyAsideHeadlineSmall {
+	@include oTypographyAsideHeadlineBase;
+	@include oTypographySerifDisplay(m);
+}
+
+/// Style for <aside> headline large variant
+@mixin oTypographyAsideHeadlineLarge {
+	@include oTypographyAsideHeadlineBase;
+	@include oTypographySerifDisplay(m);
+	font-size: 30px;
+	line-height: 31px;
+}
+
+///Style for <aside> body (<p>)
+@mixin oTypographyAsideBody {
+	@include oTypographySansData(l);
+	@include oColorsFor(o-typography-aside-text, text);
+	font-size: 18px;
+	line-height: 20px;
+	margin: 5px 0 0;
+}
+
+///Style for <aside> body (<p>) small varaint
+@mixin oTypographyAsideBodySmall {
+	@include oTypographySansData(m);
+	@include oColorsFor(o-typography-aside-text, text);
+	margin: 5px 0 0;
+}

--- a/scss/_body_aside.scss
+++ b/scss/_body_aside.scss
@@ -66,7 +66,6 @@
 
 ///Style for <aside> body (<p>)
 @mixin oTypographyAsideBody {
-	@include oTypographySansData(l);
 	@include oColorsFor(o-typography-aside-text, text);
 	font-size: 18px;
 	line-height: 20px;

--- a/scss/_body_common.scss
+++ b/scss/_body_common.scss
@@ -42,6 +42,7 @@
 
 // Caption
 @mixin oTypographyCaption {
-	@include oTypographySans(s);
+	@include oTypographySansData(m);
+	@include oTypographyItalic;
 	@include oTypographyBodyBlock;
 }

--- a/scss/_body_general.scss
+++ b/scss/_body_general.scss
@@ -16,8 +16,8 @@
 
 /// General body text (apply to body tag)
 @mixin oTypographyBody {
-	@include oTypographySans(m);
 	@include oColorsFor(body, text);
+	font: 18px/1.4 Georgia, serif;
 	margin: 0.3em 0 0.8em;
 }
 
@@ -44,4 +44,15 @@
 /// Styles for <ul> tags
 @mixin oTypographyListUnordered {
 	list-style-type: disc;
+}
+
+/// Style for <footer> tags
+@mixin oTypographyFooter {
+	@include oTypographySansData(m);
+}
+
+/// Style for <blockquote> tags
+@mixin oTypographyBlockquote {
+	@include oTypographySerifDisplay(m);
+	@include oColorsFor(o-typography-aside-text, text);
 }

--- a/scss/_color_use_cases.scss
+++ b/scss/_color_use_cases.scss
@@ -1,0 +1,1 @@
+@include oColorsSetUseCase(o-typography-aside-text, text, 'cold-1');

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -45,3 +45,16 @@
 		border-bottom: 1px dotted;
 	}
 }
+
+/// Style for subhead class
+@mixin oTypographySubhead {
+	@include oTypographySansBold(l);
+	margin-top: 50px;
+	margin-bottom: 20px;
+}
+
+/// Style for subhead crosshead class
+@mixin oTypographySubheadCrosshead {
+	@include oTypographySubhead;
+	border-bottom: 1px solid oColorsGetPaletteColor('black');
+}

--- a/scss/_type_matrix.scss
+++ b/scss/_type_matrix.scss
@@ -49,7 +49,7 @@
 		font-family: $o-typography-sans;
 		@include oTypographySansSize($level);
 	}
-	font-weight: oFontsWeight(light);
+	font-weight: oFontsWeight(regular);
 }
 
 ///

--- a/scss/_wrapped_aside.scss
+++ b/scss/_wrapped_aside.scss
@@ -1,0 +1,34 @@
+////
+/// @group Use cases
+/// @link http://registry.origami.ft.com/components/o-typography
+////
+
+/// Aside typography
+/// Apply to an aside wrapper to style all text inside it
+///
+/// @example scss
+/// article { @include oTypographyAsideWrapper; }
+@mixin oTypographyAsideWrapper {
+	h3 {
+		@include oTypographyAsideTitle;
+	}
+	h4 {
+		@include oTypographyAsideHeadline;
+	}
+	div {
+		p {
+			@include oTypographyAsideBody;
+		}
+	}
+	footer {
+		@include oTypographyBold;
+	}
+	blockquote {
+		p {
+			@include oTypographyBlockquote;
+		}
+	}
+	p {
+		margin: 5px 0 0;
+	}
+}

--- a/scss/_wrapped_general.scss
+++ b/scss/_wrapped_general.scss
@@ -10,18 +10,19 @@
 /// article { @include oTypographyBodyWrapper; }
 @mixin oTypographyBodyWrapper {
 	h1 {
+		// Article headline
 		@include oTypographyHeading1;
 	}
-
 	h2 {
-		@include oTypographyHeading2;
+		// In article body subheads
+		@include oTypographySubhead;
 	}
-
 	h3 {
+		// Headings for complementary sections / asides
 		@include oTypographyHeading3;
 	}
-
 	h4 {
+		// Headlines for other articles referenced
 		@include oTypographyHeading4;
 	}
 
@@ -37,6 +38,23 @@
 	ol,
 	ul {
 		@include oTypographyList;
+	}
+
+	footer {
+		@include oTypographyFooter;
+	}
+
+	blockquote {
+		p {
+			@include oTypographyBlockquote;
+		}
+		footer {
+			@include oTypographyBold;
+		}
+	}
+
+	aside {
+		@include oTypographyAsideWrapper;
 	}
 
 	@include oTypographyCommonWrappedBodyStyles;


### PR DESCRIPTION
OK. Ready to re-merge this and create o-typography v4.

I've also changed the aside text to match the body which is what it is in this article: https://next.ft.com/content/94e97eee-ce9a-11e5-831d-09f7778e7377

And I've replaced metric light with metric regular.
