### PR TITLE
4.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     ".travis.yml"
   ],
   "dependencies": {
-    "o-colors": "^3.4 <4",
+    "o-colors": ">=3.4 <4",
     "o-hoverable": ">=0.1.1 <4",
     "o-fonts": "^2.0.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     ".travis.yml"
   ],
   "dependencies": {
-    "o-colors": ">=2.5.0 <4",
+    "o-colors": "^3.4 <4",
     "o-hoverable": ">=0.1.1 <4",
     "o-fonts": "^2.0.0"
   }

--- a/demos/src/article.mustache
+++ b/demos/src/article.mustache
@@ -1,7 +1,7 @@
 <article class="o-grid-row demo demo-article">
 	<div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
 		<div>
-			<a href="#" class="o-typography-tag-link o-typography-tag-link--medium">Standard Chartered PLC</a>
+			<a href="#" class="o-typography-link-topic o-typography-link-topic--medium">Standard Chartered PLC</a>
 		</div>
 		<h1 class="o-typography-heading1">A ‘Rosetta stone’ that may unlock the mystery of life on Earth</h1>
 		<p class="o-typography-lead">Belgian-Brazilian brewer ups the stakes in beer takeover battle</p>

--- a/demos/src/article.mustache
+++ b/demos/src/article.mustache
@@ -1,7 +1,7 @@
 <article class="o-grid-row demo demo-article">
 	<div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
-		<div class="o-typography-flyline">
-			<a href="#" class="o-typography-flyline__link">Standard Chartered PLC</a>
+		<div>
+			<a href="#" class="o-typography-tag-link o-typography-tag-link--medium">Standard Chartered PLC</a>
 		</div>
 		<h1 class="o-typography-heading1">A ‘Rosetta stone’ that may unlock the mystery of life on Earth</h1>
 		<p class="o-typography-lead">Belgian-Brazilian brewer ups the stakes in beer takeover battle</p>

--- a/demos/src/article.mustache
+++ b/demos/src/article.mustache
@@ -5,7 +5,7 @@
 		</div>
 		<h1 class="o-typography-heading1">A ‘Rosetta stone’ that may unlock the mystery of life on Earth</h1>
 		<p class="o-typography-lead">Belgian-Brazilian brewer ups the stakes in beer takeover battle</p>
-
+		<span class="o-typography-timestamp">Today</span>
 		<div class="demo-article__body">
 			<p class="o-typography-body">Anheuser-Busch InBev raised its proposed takeover offer for SABMiller to £43.50 a share on Monday, upping the stakes in a takeover battle to create the world’s dominant brewing company, according to people familiar with the latest bid.</p>
 			<p class="o-typography-body">News of the fourth proposal by <a href="#" class="o-typography-link">AB InBev</a> for its London-listed rival, which values SABMiller’s equity at $70bn, came with less than 52 hours before a UK bid deadline.</p>

--- a/demos/src/article.mustache
+++ b/demos/src/article.mustache
@@ -39,9 +39,8 @@
 				</figcaption>
 			</figure>
 			<p class="o-typography-body">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quas aperiam magni, sint ut minus omnis eligendi velit non dolor odio optio quaerat dignissimos assumenda excepturi impedit, modi molestias iste. Suscipit tempora nemo, id ducimus vero voluptates omnis cumque provident. Eum velit temporibus consectetur officia! Sit saepe deserunt at nisi necessitatibus!</p>
-			<hr />
-			<p class="o-typography-body"><em><strong>Letter in response to this article:</strong></em></p>
-			<p class="o-typography-body"><em><a class="o-typography-link" href="#void">Spending €1.4bn for the ‘Rosetta stone’ is a tragic misappropriation of resources / From J Antoni Rafalski</a></em></p>
+			<p><span class="o-typography-subhead--standard">Letter in response to this article:</strong></p>
+			<p class='o-typography-body'><em><a class="o-typography-link" href="#void">Spending €1.4bn for the ‘Rosetta stone’ is a tragic misappropriation of resources / From J Antoni Rafalski</a></em></p>
 			<footer class="o-typography-footer">Footer such as copyright notice.</footer>
 		</div>
 	</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -19,10 +19,6 @@ html {
 		margin-right: 0;
 		margin-left: 0;
 	}
-
-	a {
-		@include oColorsFor(link);
-	}
 }
 
 .demo-article {

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -5,12 +5,7 @@ $o-typography-is-silent: false;
 html {
 	@include oColorsFor(page);
 	overflow-y: scroll;
-
 	font-family: $o-typography-sans;
-	-ms-text-size-adjust: 100%;
-	-webkit-text-size-adjust: 100%;
-	text-rendering: optimizeSpeed;
-	-webkit-font-smoothing: antialiased;
 }
 
 .demo {
@@ -31,7 +26,7 @@ html {
 }
 
 .demo-article {
-	margin: 10px 0;	
+	margin: 10px 0;
 }
 
 .demo-article__body {

--- a/main.scss
+++ b/main.scss
@@ -18,6 +18,8 @@
 @import 'scss/body_general';
 @import 'scss/headings';
 
+@import 'scss/timestamps';
+
 @import 'scss/wrapped_aside';
 @import 'scss/wrapped_common';
 @import 'scss/wrapped_general';
@@ -140,6 +142,11 @@
 	}
 	.o-typography-aside__body--small {
 		@include oTypographyAsideBodySmall;
+	}
+
+	// Timestamps usecase
+	.o-typography-timestamp {
+		@include oTypographyTimestamp;
 	}
 
 	// Body wrapper

--- a/main.scss
+++ b/main.scss
@@ -80,8 +80,13 @@
 	.o-typography-flyline {
 		@include oTypographyFlyline;
 	}
-	.o-typography-tag-link {
-		@include oTypographyTagLink;
+
+	.o-typography-link-topic {
+		@include oTypographyLinkTopic;
+	}
+
+	.o-typography-link-topic--medium {
+		@include oTypographyLinkTopicMedium;
 	}
 
 	// Body copy - general

--- a/main.scss
+++ b/main.scss
@@ -70,8 +70,14 @@
 	.o-typography-caption {
 		@include oTypographyCaption;
 	}
+
+	/// DEPRECATE THIS
 	.o-typography-flyline {
 		@include oTypographyFlyline;
+	}
+
+	.o-typography-tag-link {
+		@include oTypographyTagLink;
 	}
 
 	// Body copy - general

--- a/main.scss
+++ b/main.scss
@@ -22,6 +22,8 @@
 @import 'scss/wrapped_common';
 @import 'scss/wrapped_general';
 
+@import 'scss/_deprecated.scss';
+
 @if $o-typography-is-silent == false {
 
 	@if $o-typography-load-fonts == true {
@@ -71,11 +73,10 @@
 		@include oTypographyCaption;
 	}
 
-	/// DEPRECATE THIS
+	/// DEPRECATE THIS IN V5
 	.o-typography-flyline {
 		@include oTypographyFlyline;
 	}
-
 	.o-typography-tag-link {
 		@include oTypographyTagLink;
 	}

--- a/main.scss
+++ b/main.scss
@@ -49,6 +49,9 @@
 	.o-typography-subhead {
 		@include oTypographySubhead;
 	}
+	.o-typography-subhead--standard {
+		@include oTypographySubheadStandard;
+	}
 	.o-typography-subhead--crosshead {
 		@include oTypographySubheadCrosshead;
 	}

--- a/scss/_body_common.scss
+++ b/scss/_body_common.scss
@@ -34,9 +34,11 @@
 	@include oColorsFor(link, text);
 	text-decoration: none;
 	cursor: pointer;
+	border-bottom: 1px dotted oColorsGetColorFor(link, text);
 
 	#{$o-hoverable-if-hover-enabled} &:hover {
 		@include oColorsFor(link-hover, text);
+		border-bottom-color: transparent;
 	}
 }
 

--- a/scss/_body_general.scss
+++ b/scss/_body_general.scss
@@ -10,7 +10,7 @@
 }
 
 @mixin oTypographyLeadSmall {
-	@include oTypographySerifDisplayItalic(m);
+	@include oTypographySans(m);
 	margin: 0;
 }
 

--- a/scss/_body_general.scss
+++ b/scss/_body_general.scss
@@ -5,7 +5,7 @@
 
 /// General leader styles
 @mixin oTypographyLead {
-	@include oTypographySerifDisplayItalic(l);
+	@include oTypographySans(l);
 	margin: 0;
 }
 

--- a/scss/_color_use_cases.scss
+++ b/scss/_color_use_cases.scss
@@ -1,1 +1,2 @@
 @include oColorsSetUseCase(o-typography-aside-text, text, 'cold-1');
+@include oColorsSetUseCase(o-typography-timestamp, text, 'warm-6');

--- a/scss/_deprecated.scss
+++ b/scss/_deprecated.scss
@@ -1,0 +1,13 @@
+@mixin oTypographyFlyline {
+	@include oTypographySansBold(s);
+	text-transform: uppercase;
+	margin-bottom: 5px;
+	letter-spacing: 1px;
+
+	&__link {
+		text-decoration: none;
+	}
+	&__link:hover {
+		border-bottom: 1px dotted;
+	}
+}

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -53,6 +53,12 @@
 	margin-bottom: 20px;
 }
 
+/// Style for subhead standard
+@mixin oTypographySubheadStandard {
+	@include oTypographySubhead;
+	@include oTypographySansBold(m);
+}
+
 /// Style for subhead crosshead class
 @mixin oTypographySubheadCrosshead {
 	@include oTypographySubhead;

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -32,7 +32,7 @@
 	@include oTypographySerifDisplay(xs);
 }
 
-@mixin oTypographyTagLink {
+@mixin oTypographyLinkTopic {
 	@include oTypographySansBold(s);
 	@include oColorsFor(tag-link, text);
 	text-decoration: none;
@@ -41,8 +41,8 @@
 		@include oColorsFor(tag-link-hover, text);
 	}
 }
-@mixin oTypographyTagLinkMedium {
-	@include oTypographyTagLink;
+@mixin oTypographyLinkTopicMedium {
+	@include oTypographyLinkTopic;
 	@include oTypographySansBold(m);
 }
 

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -32,6 +32,8 @@
 	@include oTypographySerifDisplay(xs);
 }
 
+
+// DEPRECATE THIS
 @mixin oTypographyFlyline {
 	@include oTypographySansBold(s);
 	text-transform: uppercase;
@@ -44,6 +46,20 @@
 	&__link:hover {
 		border-bottom: 1px dotted;
 	}
+}
+
+@mixin oTypographyTagLink {
+	@include oTypographySansBold(s);
+	@include oColorsFor(tag-link, text);
+	text-decoration: none;
+	
+	&:hover {
+		@include oColorsFor(tag-link-hover, text);
+	}
+}
+@mixin oTypographyTagLinkMedium {
+	@include oTypographyTagLink;
+	@include oTypographySansBold(m);
 }
 
 /// Style for subhead class

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -32,27 +32,11 @@
 	@include oTypographySerifDisplay(xs);
 }
 
-
-// DEPRECATE THIS
-@mixin oTypographyFlyline {
-	@include oTypographySansBold(s);
-	text-transform: uppercase;
-	margin-bottom: 5px;
-	letter-spacing: 1px;
-
-	&__link {
-		text-decoration: none;
-	}
-	&__link:hover {
-		border-bottom: 1px dotted;
-	}
-}
-
 @mixin oTypographyTagLink {
 	@include oTypographySansBold(s);
 	@include oColorsFor(tag-link, text);
 	text-decoration: none;
-	
+
 	&:hover {
 		@include oColorsFor(tag-link-hover, text);
 	}

--- a/scss/_timestamps.scss
+++ b/scss/_timestamps.scss
@@ -1,0 +1,6 @@
+/// Style for timestamps
+@mixin oTypographyTimestamp {
+  @include oTypographySans(xs);
+  @include oColorsFor(o-typography-timestamp);
+  text-transform: uppercase;
+}


### PR DESCRIPTION
This PR:

- Soft deprecates 'Flyline' which is not used in Next anymore
- Shortens the o-colors semver range dropping support for 2.5.0. Ordinarily this would need to be a major release but since 2.x.x versions no longer build with the build service or built tools, it is safe to drop this version.
- Change Standfirst to a Sans-Serif font
- Change the lead style to a Sans-Serif font
- Add in sub-head standard style
- Update link style to next style
- Add the timestamp usecase