### PR TITLE
adding focus style to default link styles

### DIFF
--- a/scss/_body_common.scss
+++ b/scss/_body_common.scss
@@ -36,7 +36,8 @@
 	cursor: pointer;
 	border-bottom: 1px dotted oColorsGetColorFor(link, text);
 
-	#{$o-hoverable-if-hover-enabled} &:hover {
+	#{$o-hoverable-if-hover-enabled} &:hover,
+	&:focus {
 		@include oColorsFor(link-hover, text);
 		border-bottom-color: transparent;
 	}


### PR DESCRIPTION
@alicebartlett @onishiweb 

In other news, the nUiLinksTopic/oTypographyLinkTopic similarity is less strong than I'd hoped for. I'd still like to deprecate nUiLinksTopic, but I think you'd need to decide if it's safe to overwrite your mixin with an origamiized version of next's. In summary, next's goes darker on hover, whereas origami's goes lighter, and next's is opinionated about the border bottom style, whereas origami's just inherits from global link styles. Would also need to support progressive fonts