### PR TITLE
Update font matrix table to reflect current weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sans or SansBold are the common fonts for the site. SansData, SansDataBold and S
 </thead><tbody>
 <tr>
 <td><strong>Font name</strong></td>
-<td>Metric light</td>
+<td>Metric regular</td>
 <td>Metric semibold</td>
 <td>Metric regular</td>
 <td>Metric semibold</td>
@@ -36,7 +36,7 @@ Sans or SansBold are the common fonts for the site. SansData, SansDataBold and S
 </tr>
 <tr>
 <td><strong>CSS font-family (weight)</strong></td>
-<td>MetricWeb (200)</td>
+<td>MetricWeb (400)</td>
 <td>MetricWeb (600)</td>
 <td>MetricWeb (400)</td>
 <td>MetricWeb (600)</td>


### PR DESCRIPTION
Since #71 Metric Light isn't used any more.

Something to consider for v5 (maybe you've talked about this before, I dunno): now Sans is regular, does there need to be the distinction between Sans and SansData? Looks a little weird to have two identical fonts with different sizings.