### PR TITLE
Fix the name of replacement font-size mixin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ The following mixins are now renamed:
 + oTypographySans
 
 - font-size
-+ oTypographyFontSize
++ _oTypographyFontSize
 
 - oTypographyProgressiveFont
 + oTypographyProgressiveFontFallback


### PR DESCRIPTION
Sorry for the difficult-to-read diff. The change is `oTypographyFontSize ` -> `_oTypographyFontSize` (added underscore)