### PR TITLE
Fix mixin name in README (again… oops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ The following mixins are now renamed:
 + oTypographySans
 
 - font-size
-+ _oTypographyFontSize
++ oTypographySize
 
 - oTypographyProgressiveFont
 + oTypographyProgressiveFontFallback


### PR DESCRIPTION
(Change: `_oTypographyFontSize` -> `oTypographySize`)

Sorry team, my last fix was erroneous. Looking into the code, it seems the equivalent of the [old `font-size` mixin](https://github.com/Financial-Times/o-typography/blob/v4.3.4/scss/_helpers.scss#L55) would be the [`oTypographySize`](https://github.com/Financial-Times/o-typography/blob/master/src/scss/_mixins.scss#L53) mixin, since it handles line-heights too.

I regret the error 🌹