### PR TITLE
avoid double className manipulation

### DIFF
--- a/src/js/typography.js
+++ b/src/js/typography.js
@@ -7,6 +7,7 @@ class Typography {
 
 		this.opts = opts || Typography.getOptions(typographyEl);
 		this.opts = Typography.checkOptions(this.opts);
+		this.hasRun = false;
 
 		this.fontConfigs = [
 			{
@@ -93,9 +94,13 @@ class Typography {
 	}
 
 	loadFonts() {
+		if (this.hasRun) {
+			return Promise.resolve();
+		}
 		if (this.checkFontsLoaded()) {
 			this.removeLoadingClasses();
 			this.setCookie();
+			this.hasRun = true;
 			return Promise.resolve();
 		}
 
@@ -111,6 +116,7 @@ class Typography {
 			.then(() => {
 				// set value in cookie for subsequent visits
 				this.setCookie();
+				this.hasRun = true;
 			})
 			.catch(() => {});
 	}

--- a/src/js/typography.js
+++ b/src/js/typography.js
@@ -6,6 +6,9 @@ class Typography {
 		this.typographyEl = typographyEl;
 
 		this.opts = opts || Typography.getOptions(typographyEl);
+		if (typeof this.opts.loadOnInit === 'undefined') {
+			this.opts.loadOnInit = true;
+		}
 		this.opts = Typography.checkOptions(this.opts);
 		this.hasRun = false;
 
@@ -31,8 +34,9 @@ class Typography {
 				label: 'serifDisplayBold'
 			}
 		];
-
-		this.loadFonts();
+		if (this.opts.loadOnInit) {
+			this.loadFonts();
+		}
 	}
 
 	/**

--- a/test/typography.test.js
+++ b/test/typography.test.js
@@ -152,7 +152,6 @@ describe("Typography", () => {
 	});
 
 	describe("loadFonts", () => {
-		let typography;
 
 		afterEach(() => {
 			FontFaceObserver.prototype.load.restore();
@@ -255,7 +254,7 @@ describe("Typography", () => {
 							proclaim.isFalse(typography.setCookie.called);
 							typography.setCookie.restore();
 							typography.removeLoadingClasses.restore();
-						})
+						});
 				});
 		});
 

--- a/test/typography.test.js
+++ b/test/typography.test.js
@@ -68,6 +68,13 @@ describe("Typography", () => {
 
 			proclaim.isTrue(loadFontsStub.called);
 		});
+
+		it("optionally doesn't call loadFonts", () => {
+			const stubEl = "stubEL";
+			new Typography(stubEl, { loadOnInit: false });
+
+			proclaim.isFalse(loadFontsStub.called);
+		});
 	});
 
 	describe("getOptions", () => {
@@ -145,6 +152,7 @@ describe("Typography", () => {
 	});
 
 	describe("loadFonts", () => {
+		let typography;
 
 		afterEach(() => {
 			FontFaceObserver.prototype.load.restore();
@@ -154,6 +162,24 @@ describe("Typography", () => {
 		it("calls removeLoadingClasses if a cookie exists", () => {
 			const el = document.querySelector('html');
 			const typography = new Typography(el, {
+				"loadOnInit": false,
+				"fontLoadingPrefix": stubPrefix,
+				"fontLoadedCookieName": stubCookieName
+			});
+
+			document.cookie = `${stubCookieName}=1;path=/;domain=${location.hostname};`;
+			const removeLoadingClassesStub = sinon.stub(typography, 'removeLoadingClasses');
+			sinon.stub(FontFaceObserver.prototype, 'load').returns(Promise.resolve());
+
+			return typography.loadFonts().then(() => {
+				proclaim.isTrue(removeLoadingClassesStub.calledOnce);
+			});
+		});
+
+		it("calls removeLoadingClasses if a cookie exists", () => {
+			const el = document.querySelector('html');
+			const typography = new Typography(el, {
+				"loadOnInit": false,
 				"fontLoadingPrefix": stubPrefix,
 				"fontLoadedCookieName": stubCookieName
 			});
@@ -171,6 +197,7 @@ describe("Typography", () => {
 			const el = document.querySelector('html');
 			fontLabels.forEach((label) => el.classList.add(`${stubPrefix}${label}`) );
 			const typography = new Typography(el, {
+				"loadOnInit": false,
 				"fontLoadingPrefix": stubPrefix,
 				"fontLoadedCookieName": stubCookieName
 			});
@@ -191,6 +218,7 @@ describe("Typography", () => {
 		it("Adds cookie when fonts have loaded", () => {
 			const el = document.querySelector('html');
 			const typography = new Typography(el, {
+				"loadOnInit": false,
 				"fontLoadingPrefix": stubPrefix,
 				"fontLoadedCookieName": stubCookieName
 			});
@@ -204,12 +232,34 @@ describe("Typography", () => {
 
 		it("still returns when fontfaceobserver load rejects", () => {
 			const el = document.querySelector('html');
-			const typography = new Typography(el);
+			const typography = new Typography(el, {"loadOnInit": false});
 
 			sinon.stub(FontFaceObserver.prototype, 'load').returns(Promise.reject());
 
 			return typography.loadFonts();
 		});
+
+		it("is inert if has already run successfully", () => {
+			const el = document.querySelector('html');
+			const typography = new Typography(el, {"loadOnInit": false});
+
+			sinon.stub(FontFaceObserver.prototype, 'load').returns(Promise.resolve());
+
+			return typography.loadFonts()
+				.then(() => {
+					sinon.stub(typography, "removeLoadingClasses");
+					sinon.stub(typography, "setCookie");
+					return typography.loadFonts()
+						.then(() => {
+							proclaim.isFalse(typography.removeLoadingClasses.called);
+							proclaim.isFalse(typography.setCookie.called);
+							typography.setCookie.restore();
+							typography.removeLoadingClasses.restore();
+						})
+				});
+		});
+
+
 	});
 
 });


### PR DESCRIPTION
To wait for fonts to load the consumer must call `loadFonts()`, which is already called internally. this PR avoids doing the work twice if loadFonts has already executed once