### PR TITLE
Add a V5-removed mixin to the migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ v5 also removes the following mixins:
 - oTypographySerifDisplaySize
 - oTypographySerifDisplayBoldSize
 - oTypographySerifDisplayItalicSize
+- oTypographyLinkTopicMedium
 ```
 
 #### CSS classes

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ The following mixins are now renamed:
 + oTypographyHeadingLevel5
 
 - oTypographyLinkTopic
+- oTypographyLinkTopicMedium
 + oTypographyTopic
 ```
 
@@ -435,7 +436,6 @@ v5 also removes the following mixins:
 - oTypographySerifDisplaySize
 - oTypographySerifDisplayBoldSize
 - oTypographySerifDisplayItalicSize
-- oTypographyLinkTopicMedium
 ```
 
 #### CSS classes


### PR DESCRIPTION
Is this correct?
Is this necessary?
x