### PR TITLE
Add the ability to generate custom links

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,36 @@ h1 {
 }
 ```
 
+#### Custom link mixin
+
+Links in o-typography have a custom underline which uses borders. As well as the default link mixin (`oTypographyLink`), we expose `oTypographyLinkCustom` which allows you to output link styles with your own colors.
+
+This mixin accepts four arguments, all of which must be valid o-colors palette colors:
+
+- **baseColor**: The base text color of the link. This is mixed with `backgroundColor` to create the underline color.
+- **hoverColor**: The text color of the link when it's hovered or focused.
+- **backgroundColor**: The color of the background the link will sit on. Defaults to `paper`.
+- **outlineColor**: The outline color of the link when it receives focus. Defaults to `teal`.
+
+Example usage:
+
+```scss
+.my-custom-link {
+	@include oTypographyLinkCustom(
+		$baseColor: 'claret',
+		$hoverColor: 'claret-30'
+	);
+}
+
+.dark-background .my-custom-link {
+	@include oTypographyLinkCustom(
+		$baseColor: 'lemon',
+		$hoverColor: 'lemon-30',
+		$backgroundColor: 'slate'
+	);
+}
+```
+
 ### JavaScript
 
 o-typography uses JavaScript to [progressively load fonts](#progressive-loading-web-fonts) to prevent a flash of invisible content (FOIC) if the web-fonts are taking a long time to load.

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     ".travis.yml"
   ],
   "dependencies": {
-    "o-colors": "^4.0.1",
+    "o-colors": "^4.1.1",
     "o-fonts": "^3.0.0",
     "o-grid": "^4.3.1",
     "fontfaceobserver": "^2.0.9"

--- a/demos/src/custom-links.mustache
+++ b/demos/src/custom-links.mustache
@@ -1,0 +1,8 @@
+
+<p>
+	<a href="#" class="o-typography-link">Standard link</a>
+</p>
+
+<p>
+	<a href="#" class="o-typography-link--custom">Custom link</a>
+</p>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -46,3 +46,10 @@ html {
 		}
 	}
 }
+
+.o-typography-link--custom {
+	@include oTypographyLinkCustom(
+		$baseColor: 'claret',
+		$hoverColor: 'claret-30'
+	);
+}

--- a/origami.json
+++ b/origami.json
@@ -47,6 +47,12 @@
 			"template": "demos/src/all-styles.mustache",
 			"description": "",
 			"hidden": true
+		},
+		{
+			"name": "custom-links",
+			"template": "demos/src/custom-links.mustache",
+			"description": "",
+			"hidden": true
 		}
 	]
 }

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -19,23 +19,31 @@
 	vertical-align: super;
 }
 
-/// Link styles
-@mixin oTypographyLink {
-	@include oColorsFor(link, text);
+/// Custom link styles
+@mixin oTypographyLinkCustom($baseColor, $hoverColor, $backgroundColor: 'paper', $outlineColor: 'teal') {
+	color: oColorsGetPaletteColor($baseColor);
 	text-decoration: none;
 	cursor: pointer;
-	border-bottom: 2px solid oColorsMix($color: oColorsGetColorFor(link, text), $percentage: 20);
+	border-bottom: 2px solid oColorsMix(oColorsGetPaletteColor($baseColor), oColorsGetPaletteColor($backgroundColor), $percentage: 20);
 
 	&:hover,
 	&:focus {
-		color: oColorsGetPaletteColor('teal-30');
-		border-bottom-color: oColorsMix($color: oColorsGetColorFor(link, text), $percentage: 40);
+		color: oColorsGetPaletteColor($hoverColor);
+		border-bottom-color: oColorsMix(oColorsGetPaletteColor($baseColor), oColorsGetPaletteColor($backgroundColor), $percentage: 40);
 	}
 
 	&:focus {
-		outline: 3px solid oColorsGetPaletteColor('teal');
+		outline: 3px solid oColorsGetPaletteColor($outlineColor);
 		border-bottom-color: transparent;
 	}
+}
+
+/// Standard link styles
+@mixin oTypographyLink {
+	@include oTypographyLinkCustom(
+		$baseColor: oColorsGetUseCase(link, text),
+		$hoverColor: 'teal-30'
+	);
 }
 
 /// Make something italic


### PR DESCRIPTION
This includes the `oTypographyLinkCustom` mixin, which allows you to
create links with custom colors. You can only used valid o-colors
palette colors with these.

The `oTypographyLink` mixin also uses the custom links mixin.

This resolves #119