### PR TITLE
Increase headline size on tablet.

### DIFF
--- a/src/scss/use-cases/_headings.scss
+++ b/src/scss/use-cases/_headings.scss
@@ -5,7 +5,7 @@
 
 /// Headline styles
 @mixin oTypographyHeadline {
-	@include oTypographyDisplay($scale: (default: 4, L: 6));
+	@include oTypographyDisplay($scale: (default: 4, S: 5, L: 6));
 	@include oTypographyMargin($top: 0, $bottom: 5);
 	@include oColorsFor('o-typography-headline');
 	font-weight: 400; // Browser default a h# to bold...


### PR DESCRIPTION
The motivation came whilst upgrading o-typography in the web-app.

The heading used to be huge:
<img width="589" alt="article old tablet-app" src="https://user-images.githubusercontent.com/10405691/32792072-60b3de96-c95a-11e7-9ab7-ac311a442b62.png">

But now it's responsive it's maybe a bit small:
<img width="400" alt="screen shot 2017-11-14 at 16 36 39" src="https://user-images.githubusercontent.com/10405691/32792285-ea26c56c-c95a-11e7-94d4-d0c4a869c0f3.png">

So we can bump it up a little:
<img width="398" alt="screen shot 2017-11-14 at 16 37 11" src="https://user-images.githubusercontent.com/10405691/32792279-e6422cca-c95a-11e7-9240-b77de76df8d1.png">

Confirmed with @pixie-ofuono and @adgad.