### PR TITLE
Topic/author tag style updates

### DIFF
--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -5,3 +5,5 @@
 @include oColorsSetUseCase(o-typography-caption, text, 'black-80');
 @include oColorsSetUseCase(o-typography-list-prefix, text, 'claret');
 @include oColorsSetUseCase(o-typography-blockquote, border, 'claret');
+@include oColorsSetUseCase(o-typography-author, text, 'black-80');
+@include oColorsSetUseCase(o-typography-author-hover, text, 'claret');

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,4 +1,4 @@
-@include oColorsSetUseCase(o-typography-timestamp, text, 'black-80');
+@include oColorsSetUseCase(o-typography-timestamp, text, 'black-60');
 @include oColorsSetUseCase(o-typography-headline, text, 'black-80');
 @include oColorsSetUseCase(o-typography-body, text, 'black-80');
 @include oColorsSetUseCase(o-typography-standfirst, text, 'black-60');

--- a/src/scss/use-cases/_article.scss
+++ b/src/scss/use-cases/_article.scss
@@ -7,7 +7,7 @@
 
 /// Style for timestamps
 @mixin oTypographyTimestamp {
-  @include oTypographySans($scale: -1);
+  @include oTypographySans($scale: 0);
   @include oColorsFor(o-typography-timestamp);
   @include oTypographyMargin($bottom: 4);
   display: inline-block;
@@ -53,12 +53,11 @@
 /// Article author styles - inherits from oTypographyTag mixin
 @mixin oTypographyAuthor {
 	@include oTypographyTag;
-	@include oTypographySansBold($scale: -1);
+	@include oTypographySansBold($scale: 0);
 	@include oColorsFor('o-typography-author', text);
 	&:hover {
 		@include oColorsFor('o-typography-author-hover', text);
 	}
-
 }
 
 /// Article Topic styles - inherits from oTypographyTag mixin

--- a/src/scss/use-cases/_article.scss
+++ b/src/scss/use-cases/_article.scss
@@ -28,6 +28,7 @@
 @mixin oTypographyTag {
 	@include oColorsFor(tag-link, text);
 	text-decoration: none;
+	border: 0;
 	display: inline-block;
 
 	&:hover {
@@ -38,6 +39,10 @@
 		color: inherit;
 		cursor: pointer;
 		text-decoration: none;
+		border: 0;
+		&:hover {
+			color: inherit;
+		}
 	}
 
 	span {
@@ -49,12 +54,17 @@
 @mixin oTypographyAuthor {
 	@include oTypographyTag;
 	@include oTypographySansBold($scale: -1);
+	@include oColorsFor('o-typography-author', text);
+	&:hover {
+		@include oColorsFor('o-typography-author-hover', text);
+	}
+
 }
 
 /// Article Topic styles - inherits from oTypographyTag mixin
 @mixin oTypographyTopic {
 	@include oTypographyTag;
-	@include oTypographySansBold($scale: 1);
+	@include oTypographySansBold($scale: 0);
 }
 
 /// Style for <footer> tags


### PR DESCRIPTION
As part of some upgrades to n-ui, we're starting to use oTypographyTopic. But we also apply oTypographyLink on all `a` tag, so need to unset the border.

While I'm here, also making some changes to make it match the styles we use on the article page, namely (checked with @luketudorgriffiths):

* Smaller font for topic tags.
* Black for author tags.

/cc @GlynnPhillips @quarterto is this going to break anything for you?

Before: 

<img width="793" alt="screen shot 2017-11-16 at 12 06 09" src="https://user-images.githubusercontent.com/1978880/32890459-bcd6fd94-cac6-11e7-8eeb-0a66c0426d90.png">

After:

<img width="808" alt="screen shot 2017-11-16 at 12 05 44" src="https://user-images.githubusercontent.com/1978880/32890464-c38dd6f8-cac6-11e7-92df-84bd341eed18.png">

