### PR TITLE
add product heading styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Typographical styles for FT branded sites - font families, weight, colors, sizes
 		- [Responsive font scales](#responsive-font-scales)
 		- [Progressive loading web fonts](#progressive-loading-web-fonts)
 		- [Baseline grid mixins](#baseline-grid-mixins)
+		- [Custom Link mixin](#custom-link-mixin)
+		- [Heading mixins](#heading-mixins)
 - [Troubleshooting](#troubleshooting)
 - [Migration guide](#migration-guide)
 - [Contact](#contact)
@@ -370,6 +372,62 @@ Example usage:
 	);
 }
 ```
+
+#### Heading mixins
+
+Headings in o-typography have a specific font-family, and some additional styling depending on the functionality of the heading.
+
+There are two groups of mixins that are available to style headings, one for article headings, and one for headings that support other types of content, which we are calling 'product'.
+
+The following are two examples of many available mixins.
+
+`oTypographyHeadline` will output styles for an article headline.
+
+Usage:
+
+```scss
+.my-article-headline {
+	@include oTypographyHeadline();
+}
+```
+
+Output:
+
+```css
+.my-article-headline {
+	font-family: FinancierDisplayWeb, serif;
+	font-size: 32px;
+	line-height: 32px;
+	font-weight: 700;
+	margin-top: 0px;
+	margin-bottom: 28px;
+	color: #33302e;
+}
+```
+
+`oTypographyProductHeadingLevel1` is an example of the product variant for an `h1`.
+
+Usage:
+```scss
+.my-non-article-headline {
+	@include oTypographyProductHeadingLevel1();
+}
+```
+
+Output:
+```css
+.my-non-article-headline {
+	margin-top: 0px;
+	margin-bottom: 20px;
+	color: #33302e;
+	font-family: MetricWeb, sans-serif;
+	font-size: 32px;
+	line-height: 32px;
+	font-weight: 600;
+}
+```
+
+There are multiple mixins for article headings and for product headings, examples of which can be found in the [`o-typography` demos](http://registry.origami.ft.com/components/o-typography).
 
 ### JavaScript
 

--- a/demos/src/product-headings.mustache
+++ b/demos/src/product-headings.mustache
@@ -7,4 +7,3 @@
 <h3 class="o-typography-product-heading-level-6">Heading level 6 &mdash; Don&rsquo;t settle for black and white</h3>
 <h4 class="o-typography-product-heading-level-7">Heading level 7 &mdash; Don&rsquo;t settle for black and white</h4>
 <h5 class="o-typography-product-heading-level-8">Heading level 8 &mdash; Don&rsquo;t settle for black and white</h5>
-<h5 class="o-typography-product-field-label">Field Label &mdash; Don&rsquo;t settle for black and white</h5>

--- a/demos/src/product-headings.mustache
+++ b/demos/src/product-headings.mustache
@@ -1,0 +1,10 @@
+
+<h2 class="o-typography-product-heading-level-1">Heading level 1 &mdash; Don&rsquo;t settle for black and white</h2>
+<h2 class="o-typography-product-heading-level-2">Heading level 2 &mdash; Don&rsquo;t settle for black and white</h2>
+<h3 class="o-typography-product-heading-level-3">Heading level 3 &mdash; Don&rsquo;t settle for black and white</h3>
+<h4 class="o-typography-product-heading-level-4">Heading level 4 &mdash; Don&rsquo;t settle for black and white</h4>
+<h5 class="o-typography-product-heading-level-5">Heading level 5 &mdash; Don&rsquo;t settle for black and white</h5>
+<h3 class="o-typography-product-heading-level-6">Heading level 6 &mdash; Don&rsquo;t settle for black and white</h3>
+<h4 class="o-typography-product-heading-level-7">Heading level 7 &mdash; Don&rsquo;t settle for black and white</h4>
+<h5 class="o-typography-product-heading-level-8">Heading level 8 &mdash; Don&rsquo;t settle for black and white</h5>
+<h5 class="o-typography-product-field-label">Field Label &mdash; Don&rsquo;t settle for black and white</h5>

--- a/main.scss
+++ b/main.scss
@@ -171,6 +171,11 @@
 		@include oTypographyWrapper;
 	}
 
+	// Body wrapper for non-article related products
+	.o-typography-wrapper--product {
+		@include oTypographyWrapper($style: product);
+	}
+
 	// Don't output twice
 	$o-typography-is-silent: true !global;
 }

--- a/main.scss
+++ b/main.scss
@@ -16,6 +16,7 @@
 
 @import 'src/scss/use-cases/general';
 @import 'src/scss/use-cases/headings';
+@import 'src/scss/use-cases/product-headings';
 @import 'src/scss/use-cases/article';
 @import 'src/scss/use-cases/asides';
 @import 'src/scss/use-cases/wrapper';
@@ -60,6 +61,44 @@
 
 	.o-typography-collection-heading {
 		@include oTypographyCollectionHeader;
+	}
+
+	// Product Headings
+
+	.o-typography-product-heading-level-1 {
+		@include oTypographyProductHeadingLevel1;
+	}
+
+	.o-typography-product-heading-level-2 {
+		@include oTypographyProductHeadingLevel2;
+	}
+
+	.o-typography-product-heading-level-3 {
+		@include oTypographyProductHeadingLevel3;
+	}
+
+	.o-typography-product-heading-level-4 {
+		@include oTypographyProductHeadingLevel4;
+	}
+
+	.o-typography-product-heading-level-5 {
+		@include oTypographyProductHeadingLevel5;
+	}
+
+	.o-typography-product-heading-level-6 {
+		@include oTypographyProductHeadingLevel6;
+	}
+
+	.o-typography-product-heading-level-7 {
+		@include oTypographyProductHeadingLevel7;
+	}
+
+	.o-typography-product-heading-level-8 {
+		@include oTypographyProductHeadingLevel8;
+	}
+
+	.o-typography-product-field-label {
+		@include oTypographyProductFieldLabel;
 	}
 
 	// Body copy - common

--- a/main.scss
+++ b/main.scss
@@ -97,10 +97,6 @@
 		@include oTypographyProductHeadingLevel8;
 	}
 
-	.o-typography-product-field-label {
-		@include oTypographyProductFieldLabel;
-	}
-
 	// Body copy - common
 	.o-typography-bold {
 		@include oTypographyBold;

--- a/origami.json
+++ b/origami.json
@@ -41,6 +41,11 @@
 			"description": ""
 		},
 		{
+			"name": "product-headings",
+			"template": "demos/src/product-headings.mustache",
+			"description": ""
+		},
+		{
 			"name": "all-styles",
 			"template": "demos/src/all-styles.mustache",
 			"description": "",

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -7,3 +7,5 @@
 @include oColorsSetUseCase(o-typography-blockquote, border, 'claret');
 @include oColorsSetUseCase(o-typography-author, text, 'black-80');
 @include oColorsSetUseCase(o-typography-author-hover, text, 'claret');
+
+@include oColorsSetUseCase(o-typography-product-field-label, text, 'black-20');

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -7,5 +7,3 @@
 @include oColorsSetUseCase(o-typography-blockquote, border, 'claret');
 @include oColorsSetUseCase(o-typography-author, text, 'black-80');
 @include oColorsSetUseCase(o-typography-author-hover, text, 'claret');
-
-@include oColorsSetUseCase(o-typography-product-field-label, text, 'black-20');

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,3 +1,16 @@
+@mixin _oTypographyProductHeadingBase($scale,$weight: 'regular') {
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+	@if $weight == 'regular' {
+		@include oTypographySans($scale: $scale);
+		font-weight: 400;
+	} @else if $weight == 'bold' {
+		@include oTypographySansBold($scale: $scale);
+	} @else {
+		@error '#{$weight} is not a defined weight in oTypography';
+	}
+}
+
 /// Outputs the font size based on the scale, also accepts a font adjustment
 /// parameter for when outputting styles for progressively loaded fonts
 ///

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,10 +1,15 @@
-@mixin _oTypographyProductHeadingBase($scale,$weight: 'regular') {
+/// Outputs styling for headings, namely the font size based on the scale and the font-weight based on preference,
+/// along with the base colour
+///
+/// @param {Number} $scale number on scale the sizes are based on
+/// @param {String} $weight to determine which font to load
+@mixin _oTypographyProductHeadingBase($scale, $weight: regular) {
 	@include oTypographyMargin($top: 0, $bottom: 5);
 	@include oColorsFor('o-typography-headline');
-	@if $weight == 'regular' {
+	@if $weight == regular {
 		@include oTypographySans($scale: $scale);
 		font-weight: 400;
-	} @else if $weight == 'bold' {
+	} @else if $weight == semibold {
 		@include oTypographySansBold($scale: $scale);
 	} @else {
 		@error '#{$weight} is not a defined weight in oTypography';

--- a/src/scss/use-cases/_headings.scss
+++ b/src/scss/use-cases/_headings.scss
@@ -28,34 +28,22 @@
 
 /// Level 2 heading styles
 @mixin oTypographyHeadingLevel2 {
-
-	@include oTypographySansBold($scale: 4);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
+	@include _oTypographyProductHeadingBase($scale: 4, $weight: bold);
 }
 
 /// Level 3 heading styles
 @mixin oTypographyHeadingLevel3 {
-	@include oTypographySans($scale: 4);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
-	font-weight: 400;
+	@include _oTypographyProductHeadingBase($scale: 4);
 }
 
 /// Level 4 heading styles
 @mixin oTypographyHeadingLevel4 {
-	@include oTypographySans($scale: 3);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
-	font-weight: 400;
+	@include _oTypographyProductHeadingBase($scale: 3);
 }
 
 /// Level 5 heading styles
 @mixin oTypographyHeadingLevel5 {
-	@include oTypographySans($scale: 0);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
-	font-weight: 400;
+	@include _oTypographyProductHeadingBase($scale: 0);
 	text-transform: uppercase;
 	letter-spacing: 0.5px;
 }

--- a/src/scss/use-cases/_headings.scss
+++ b/src/scss/use-cases/_headings.scss
@@ -28,7 +28,7 @@
 
 /// Level 2 heading styles
 @mixin oTypographyHeadingLevel2 {
-	@include _oTypographyProductHeadingBase($scale: 4, $weight: bold);
+	@include _oTypographyProductHeadingBase($scale: 4, $weight: semibold);
 }
 
 /// Level 3 heading styles

--- a/src/scss/use-cases/_product-headings.scss
+++ b/src/scss/use-cases/_product-headings.scss
@@ -5,7 +5,7 @@
 
 /// Level 1 product heading styles
 @mixin oTypographyProductHeadingLevel1 {
-	@include _oTypographyProductHeadingBase($scale: 5, $weight: bold);
+	@include _oTypographyProductHeadingBase($scale: 5, $weight: semibold);
 }
 
 /// Level 2 product heading styles
@@ -15,7 +15,7 @@
 
 /// Level 3 product heading styles
 @mixin oTypographyProductHeadingLevel3 {
-	@include _oTypographyProductHeadingBase($scale: 4, $weight: bold);
+	@include _oTypographyProductHeadingBase($scale: 4, $weight: semibold);
 }
 
 /// Level 4 heading styles
@@ -25,7 +25,7 @@
 
 /// Level 5 heading styles
 @mixin oTypographyProductHeadingLevel5 {
-	@include _oTypographyProductHeadingBase($scale: 3, $weight: bold);
+	@include _oTypographyProductHeadingBase($scale: 3, $weight: semibold);
 }
 
 /// Level 6 heading styles
@@ -35,7 +35,7 @@
 
 /// Level 7 heading styles
 @mixin oTypographyProductHeadingLevel7 {
-	@include _oTypographyProductHeadingBase($scale: 2, $weight: bold);
+	@include _oTypographyProductHeadingBase($scale: 2, $weight: semibold);
 }
 
 /// Level 8 heading styles

--- a/src/scss/use-cases/_product-headings.scss
+++ b/src/scss/use-cases/_product-headings.scss
@@ -5,60 +5,40 @@
 
 /// Level 1 product heading styles
 @mixin oTypographyProductHeadingLevel1 {
-	@include oTypographySansBold($scale: 5);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
+	@include _oTypographyProductHeadingBase($scale: 5, $weight: bold);
 }
 
 /// Level 2 product heading styles
 @mixin oTypographyProductHeadingLevel2 {
-	@include oTypographySans($scale: 5);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
-	font-weight: 400;
+	@include _oTypographyProductHeadingBase($scale: 5);
 }
 
 /// Level 3 product heading styles
 @mixin oTypographyProductHeadingLevel3 {
-	@include oTypographySansBold($scale: 4);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
+	@include _oTypographyProductHeadingBase($scale: 4, $weight: bold);
 }
 
 /// Level 4 heading styles
 @mixin oTypographyProductHeadingLevel4 {
-	@include oTypographySans($scale: 4);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
-	font-weight: 400;
+	@include _oTypographyProductHeadingBase($scale: 4);
 }
 
 /// Level 5 heading styles
 @mixin oTypographyProductHeadingLevel5 {
-	@include oTypographySansBold($scale: 3);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
+	@include _oTypographyProductHeadingBase($scale: 3, $weight: bold);
 }
 
 /// Level 6 heading styles
 @mixin oTypographyProductHeadingLevel6 {
-	@include oTypographySans($scale: 3);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
-	font-weight: 400;
+	@include _oTypographyProductHeadingBase($scale: 3);
 }
 
 /// Level 7 heading styles
 @mixin oTypographyProductHeadingLevel7 {
-	@include oTypographySansBold($scale: 2);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
+	@include _oTypographyProductHeadingBase($scale: 2, $weight: bold);
 }
 
 /// Level 8 heading styles
 @mixin oTypographyProductHeadingLevel8 {
-	@include oTypographySans($scale: 2);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-headline');
-	font-weight: 400;
+	@include _oTypographyProductHeadingBase($scale: 2);
 }

--- a/src/scss/use-cases/_product-headings.scss
+++ b/src/scss/use-cases/_product-headings.scss
@@ -62,10 +62,3 @@
 	@include oColorsFor('o-typography-headline');
 	font-weight: 400;
 }
-
-/// Product Field Label styles
-@mixin oTypographyProductFieldLabel {
-	@include oTypographySansBold($scale: 0);
-	@include oTypographyMargin($top: 0, $bottom: 5);
-	@include oColorsFor('o-typography-product-field-label');
-}

--- a/src/scss/use-cases/_product-headings.scss
+++ b/src/scss/use-cases/_product-headings.scss
@@ -1,0 +1,71 @@
+////
+/// @group Use cases
+/// @link http://registry.origami.ft.com/components/o-typography
+////
+
+/// Level 1 product heading styles
+@mixin oTypographyProductHeadingLevel1 {
+	@include oTypographySansBold($scale: 5);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+}
+
+/// Level 2 product heading styles
+@mixin oTypographyProductHeadingLevel2 {
+	@include oTypographySans($scale: 5);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+	font-weight: 400;
+}
+
+/// Level 3 product heading styles
+@mixin oTypographyProductHeadingLevel3 {
+	@include oTypographySansBold($scale: 4);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+}
+
+/// Level 4 heading styles
+@mixin oTypographyProductHeadingLevel4 {
+	@include oTypographySans($scale: 4);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+	font-weight: 400;
+}
+
+/// Level 5 heading styles
+@mixin oTypographyProductHeadingLevel5 {
+	@include oTypographySansBold($scale: 3);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+}
+
+/// Level 6 heading styles
+@mixin oTypographyProductHeadingLevel6 {
+	@include oTypographySans($scale: 3);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+	font-weight: 400;
+}
+
+/// Level 7 heading styles
+@mixin oTypographyProductHeadingLevel7 {
+	@include oTypographySansBold($scale: 2);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+}
+
+/// Level 8 heading styles
+@mixin oTypographyProductHeadingLevel8 {
+	@include oTypographySans($scale: 2);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-headline');
+	font-weight: 400;
+}
+
+/// Product Field Label styles
+@mixin oTypographyProductFieldLabel {
+	@include oTypographySansBold($scale: 0);
+	@include oTypographyMargin($top: 0, $bottom: 5);
+	@include oColorsFor('o-typography-product-field-label');
+}

--- a/src/scss/use-cases/_wrapper.scss
+++ b/src/scss/use-cases/_wrapper.scss
@@ -6,11 +6,12 @@
 /// General typography
 /// Apply to a wrapper to style all text inside it
 ///
+/// @param {String} $style will change the headings in a body that is not an article
 /// @example scss
 /// article { @include oTypographyWrapper; }
-/// non-article { @include oTypographyWrapper($style: 'product'); }
-@mixin oTypographyWrapper($style: 'article') {
-	@if $style == 'article' {
+/// non-article { @include oTypographyWrapper($style: product); }
+@mixin oTypographyWrapper($style: article) {
+	@if $style == article {
 		h1 {
 			// Article headline
 			@include oTypographyHeadline;

--- a/src/scss/use-cases/_wrapper.scss
+++ b/src/scss/use-cases/_wrapper.scss
@@ -8,31 +8,65 @@
 ///
 /// @example scss
 /// article { @include oTypographyWrapper; }
-@mixin oTypographyWrapper {
-	h1 {
-		// Article headline
-		@include oTypographyHeadline;
+/// non-article { @include oTypographyWrapper($style: 'product'); }
+@mixin oTypographyWrapper($style: 'article') {
+	@if $style == 'article' {
+		h1 {
+			// Article headline
+			@include oTypographyHeadline;
+		}
+
+		h2 {
+			// In article body subheads
+			@include oTypographyHeadingLevel2;
+		}
+
+		h3 {
+			// Headings for complementary sections / asides
+			@include oTypographyHeadingLevel3;
+		}
+
+		h4 {
+			// Headlines for other articles referenced
+			@include oTypographyHeadingLevel4;
+		}
+
+		h5 {
+			// Headlines for other articles referenced
+			@include oTypographyHeadingLevel5;
+		}
+	} @else {
+		h1 {
+			// Non-article headline
+			@include oTypographyProductHeadingLevel1;
+		}
+
+		h2 {
+			// Non-article headings
+			@include oTypographyProductHeadingLevel2;
+		}
+
+		h3 {
+			// Non-article headings for complementary sections / asides
+			@include oTypographyProductHeadingLevel3;
+		}
+
+		h4 {
+			// Non-article headlines for other references
+			@include oTypographyProductHeadingLevel4;
+		}
+
+		h5 {
+			// Non-article headlines for other references
+			@include oTypographyProductHeadingLevel5;
+		}
+
+		h6 {
+			// Non-article headlines for other references
+			@include oTypographyProductHeadingLevel6;
+		}
 	}
 
-	h2 {
-		// In article body subheads
-		@include oTypographyHeadingLevel2;
-	}
-
-	h3 {
-		// Headings for complementary sections / asides
-		@include oTypographyHeadingLevel3;
-	}
-
-	h4 {
-		// Headlines for other articles referenced
-		@include oTypographyHeadingLevel4;
-	}
-
-	h5 {
-		// Headlines for other articles referenced
-		@include oTypographyHeadingLevel5;
-	}
 
 	a {
 		@include oTypographyLink;


### PR DESCRIPTION
This PR adds the changes requested by James, #133 and looks like this:

<img width="604" alt="screen shot 2018-02-06 at 14 22 04" src="https://user-images.githubusercontent.com/16777943/35864273-3945cbfe-0b49-11e8-9b3c-69d1739cbcc6.png">

@notlee I think we may need to consider branding for oTypography for this kind of thing, but in the future so that this is not a breaking change. 

Closes #133 