### PR TITLE
Add variant of product heading level 7 with thin border

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -97,6 +97,13 @@
 		@include oTypographyProductHeadingLevel8;
 	}
 
+	.o-typography-product-heading-level-7--thin-rule {
+		@include oTypographyProductHeadingLevel7;
+		border-top: 1px solid oColorsGetPaletteColor('black-30');
+		padding-top: oTypographySpacingSize(3);
+		margin-bottom: oTypographySpacingSize(1);
+	}
+
 	// Body copy - common
 	.o-typography-bold {
 		@include oTypographyBold;


### PR DESCRIPTION
This style (from @draysonandstock inc) is used across more than one app so it made sense to extract it. (eg. consent forms, myFT)
 
Eg Product announcements header:

![image](https://user-images.githubusercontent.com/471250/38936356-7dc955aa-4318-11e8-936d-7143d70b2cad.png)

