### PR TITLE
Add external link class / mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ h1 {
 
 Links in o-typography have a custom underline which uses borders. As well as the default link mixin (`oTypographyLink`), we expose `oTypographyLinkCustom` which allows you to output link styles with your own colors.
 
+For a link that launches another window / tab, use oTypographyLinkExternal.
+
 This mixin accepts four arguments, all of which must be valid o-colors palette colors:
 
 - **baseColor**: The base text color of the link. This is mixed with `backgroundColor` to create the underline color.

--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "o-colors": "^4.1.1",
     "o-fonts": "^3.0.0",
     "o-grid": "^4.3.1",
-    "fontfaceobserver": "^2.0.9"
+    "fontfaceobserver": "^2.0.9",
+    "o-icons": "^5.6.1"
   }
 }

--- a/demos/src/custom-links.mustache
+++ b/demos/src/custom-links.mustache
@@ -4,5 +4,9 @@
 </p>
 
 <p>
+	<a href="#" class="o-typography-link--external">External link</a>
+</p>
+
+<p>
 	<a href="#" class="o-typography-link--custom">Custom link</a>
 </p>

--- a/main.scss
+++ b/main.scss
@@ -6,6 +6,7 @@
 @import 'o-grid/main';
 @import 'o-fonts/main';
 @import 'o-colors/main';
+@import 'o-icons/main';
 
 @import 'src/scss/variables';
 @import 'src/scss/color-use-cases';
@@ -115,6 +116,10 @@
 
 	.o-typography-link {
 		@include oTypographyLink;
+	}
+
+	.o-typography-link--external {
+		@include oTypographyLinkExternal;
 	}
 
 	.o-typography-caption {

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -46,6 +46,21 @@
 	);
 }
 
+@mixin oTypographyLinkExternal {
+	@include oTypographyLink;
+	position: relative;
+	white-space: nowrap;
+	&::after {
+		@include oIconsGetIcon('outside-page', oColorsGetPaletteColor('teal'), 24);
+		content: '';
+		display: block;
+		position: absolute;
+		right: oTypographySpacingSize(6) * -1;
+		top: 50%;
+		transform: translateY(-50%);
+	}
+}
+
 /// Make something italic
 @mixin oTypographyItalic {
 	font-style: italic;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/471250/38940210-898b36a2-4321-11e8-909b-819f2a935a2c.png)

- @draysonandstock preference was that the link text isn't allowed to partly wrap to another line