### PR TITLE
External link class - set right margin to accomodate icon

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -48,6 +48,7 @@
 
 @mixin oTypographyLinkExternal {
 	@include oTypographyLink;
+	margin-right: oTypographySpacingSize(6);
 	position: relative;
 	white-space: nowrap;
 	&::after {


### PR DESCRIPTION
Follow-up to https://github.com/Financial-Times/o-typography/pull/139
