### PR TITLE
Support progressive font loading via the build service.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,8 @@
 {
   "name": "o-typography",
   "main": [
-    "main.scss"
+    "main.scss",
+    "main.js"
   ],
   "ignore": [
     ".travis.yml"


### PR DESCRIPTION
This [is documented](https://github.com/Financial-Times/o-typography#progressive-loading-web-fonts) but not currently possible as OBT does not find and build the JS.