### PR TITLE
Fix progressive loading of the display font.

### DIFF
--- a/src/js/typography.js
+++ b/src/js/typography.js
@@ -19,7 +19,7 @@ class Typography {
 			{
 				family: 'FinancierDisplayWeb',
 				weight: 'normal',
-				label: 'serifDisplay'
+				label: 'display'
 			},
 			{
 				family: 'MetricWeb',
@@ -34,7 +34,7 @@ class Typography {
 			{
 				family: 'FinancierDisplayWeb',
 				weight: 700,
-				label: 'serifDisplayBold'
+				label: 'displayBold'
 			}
 		];
 		if (this.opts.loadOnInit) {

--- a/test/typography.test.js
+++ b/test/typography.test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon/pkg/sinon';
 
 import Typography from './../main';
 
-const fontLabels = ['serifDisplay', 'sans', 'sansBold', 'serifDisplayBold'];
+const fontLabels = ['display', 'sans', 'sansBold', 'displayBold'];
 const stubPrefix = 'loading-font-';
 const stubCookieName = 'fonts-loaded';
 


### PR DESCRIPTION
This updates `display` labels to match those used in the css https://github.com/Financial-Times/o-typography/blob/master/src/scss/_type-mixins.scss#L36

It looks like its been this way for a while: https://github.com/Financial-Times/o-typography/commit/cd7bb58f07676e0c64d71adf771847610e527390#diff-cc5f92b397da4aef0ff4fed64a71a7a4L410

o-typography logic is duplicated in n-ui. Will submit a separate PR there.
https://github.com/Financial-Times/n-ui/blob/b08b20bf757bab1103f09adfecb22a90feebca36/browser/layout/partials/enhance-fonts.html#L3

Before (core)
<img width="1018" alt="screen shot 2018-05-24 at 17 11 53" src="https://user-images.githubusercontent.com/10405691/40498007-9dad099c-5f75-11e8-99b1-1dfeb7a53cc5.png">

After (core)
<img width="997" alt="screen shot 2018-05-24 at 17 11 58" src="https://user-images.githubusercontent.com/10405691/40498008-9dcd88c0-5f75-11e8-9864-3d81d6f141ff.png">
