### PR TITLE
Enable external links to wrap.

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -47,18 +47,19 @@
 }
 
 @mixin oTypographyLinkExternal {
+	$icon-size: #{(24 / 16)}em;
 	@include oTypographyLink;
-	margin-right: oTypographySpacingSize(6);
-	position: relative;
-	white-space: nowrap;
+	margin-right: calc(1em + 0.25ch);
 	&::after {
 		@include oIconsGetIcon('outside-page', oColorsGetPaletteColor('teal'), 24, $iconset-version: 1);
 		content: '';
-		display: block;
-		position: absolute;
-		right: oTypographySpacingSize(6) * -1;
-		top: 50%;
-		transform: translateY(-50%);
+		width: 1em;
+		height: 1em;
+		vertical-align: bottom;
+		background-size: $icon-size;
+		margin-right: calc(-1em - 0.25ch);
+		padding-left: 0.25ch;
+		background-origin: content-box;
 	}
 }
 


### PR DESCRIPTION
Before:
![screen shot 2018-05-31 at 14 15 55](https://user-images.githubusercontent.com/10405691/40784532-d1ccac4c-64dd-11e8-92f9-06afb49e83d5.png)

After:
![screen shot 2018-05-31 at 14 15 49](https://user-images.githubusercontent.com/10405691/40784542-d76d9260-64dd-11e8-9fa8-8208aa263904.png)

Space either side of the icon has been tightened in the process. Thoughts?:
Before/After
<img width="736" alt="screen shot 2018-05-31 at 14 22 10" src="https://user-images.githubusercontent.com/10405691/40784623-0fcaf364-64de-11e8-878d-4cd7ca228c9c.png">

![kapture 2018-05-31 at 14 18 02](https://user-images.githubusercontent.com/10405691/40784558-e0db986a-64dd-11e8-9787-aaeffec1814d.gif)
