### PR TITLE
Make bullet sizes relative

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -126,7 +126,7 @@
 			display: inline-block;
 			position: absolute;
 			content: '\2022'; // dot character
-			left: -0.25ch;
+			left: -0.0625em;
 			font-size: 1.777777778em; // font-size 32px for `li` items with font-size of 18px
 		}
 	}

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -111,22 +111,23 @@
 }
 
 /// Styles for <ul> tags
+/// Bullet size and spacing was suited to article font-size (18px at time of writing).
+/// This has since been updated to use `em` units but maintain that ratio.
 @mixin oTypographyListUnordered {
 	padding-left: 0;
 
 	li {
 		display: block;
 		position: relative;
-		padding-left: oTypographySpacingSize($units: 6);
+		padding-left: 1.333333333em; // padding-left 24px for `li` items with font-size of 18px
 
 		&:before {
 			@include oColorsFor('o-typography-list-prefix');
 			display: inline-block;
 			position: absolute;
 			content: '\2022'; // dot character
-			top: -3px; // magic number alignment
-			left: -2px;
-			font-size: oTypographySpacingSize($units: 8);
+			left: -0.25ch;
+			font-size: 1.777777778em; // font-size 32px for `li` items with font-size of 18px
 		}
 	}
 }


### PR DESCRIPTION
Now scales according to list font size. E.g. a small metric font:

<img width="810" alt="screen shot 2018-05-31 at 17 32 40" src="https://user-images.githubusercontent.com/10405691/40795068-c9bf3400-64f8-11e8-94de-2132dbc40c9b.png">

Updates the bullet position, aligning centre within the line height (.gif: waitttt forrrrr itttt):
![kapture 2018-05-31 at 17 32 08](https://user-images.githubusercontent.com/10405691/40795047-bbd5a0cc-64f8-11e8-8046-856b5cf750ff.gif)
