### PR TITLE
Improve external link in IE. Break out external link mixin for icon / icon position.

### DIFF
--- a/demos/src/custom-links.mustache
+++ b/demos/src/custom-links.mustache
@@ -8,5 +8,9 @@
 </p>
 
 <p>
+	Here is content with an <a href="#" class="o-typography-link--external">external link</a>. And more content.
+</p>
+
+<p>
 	<a href="#" class="o-typography-link--custom">Custom link</a>
 </p>

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -46,26 +46,35 @@
 	);
 }
 
+/// Standard link styles + external link icon.
 @mixin oTypographyLinkExternal {
+	@include oTypographyLink;
+	@include oTypographyLinkExternalIcon(oColorsGetPaletteColor('teal'));
+}
+
+/// External link icon.
+/// @param {Color} $color of the icon
+@mixin oTypographyLinkExternalIcon($color) {
 	// Icons align to a 40x40 pixel grid with 10px padding on each side.
 	// In this case however we want to remove that padding to align the icon flush.
 	// https://github.com/Financial-Times/fticons/blob/master/contributing.md#design
 	$icon-size: (24 / 16) * 1em;
 	$icon-padding: ($icon-size/40) * 10;
-	$icon-container-size: $icon-size - ($icon-padding * 2);
-	@include oTypographyLink;
-	margin-right: calc(#{$icon-container-size} + 0.5ch); // Space for icon (without border).
+	$margin: 0.5ch;
+	margin-right: calc(#{$icon-size} - #{$icon-padding * 2} + #{$margin}); // Space for icon.
 	&::after {
-		@include oIconsGetIcon('outside-page', oColorsGetPaletteColor('teal'), 24, $iconset-version: 1);
+		@include oIconsGetIcon('outside-page', $color, 24, $iconset-version: 1);
 		content: '';
-		width: $icon-container-size;
-		height: $icon-container-size;
-		vertical-align: inherit;
-		background-size: $icon-size;
-		background-position-x: right\0; // IE9 hack to position resized background
+		width: $icon-size;
+		height: $icon-size;
+		margin: -#{$icon-padding};
+		margin-right: calc(-#{$icon-size} + #{$icon-padding} - #{$margin});
 		padding-left: 0.5ch;
-		margin-right: calc(-#{$icon-container-size} - 0.5ch);
 		background-origin: content-box;
+		vertical-align: middle;
+		// To align middle ignoring any link border.
+		border-bottom: inherit;
+    	border-color: transparent;
 	}
 }
 


### PR DESCRIPTION
Icon size/position is now correct in IE, including IE9.
<img width="1136" alt="screen shot 2018-06-04 at 16 46 17" src="https://user-images.githubusercontent.com/10405691/40927799-906dddce-6817-11e8-90d1-762296aa5eb5.png">

New mixin can be used to output the external link icon in other contexts, e.g:
<img width="532" alt="screen shot 2018-06-04 at 16 46 59" src="https://user-images.githubusercontent.com/10405691/40927841-a78675de-6817-11e8-9d37-c6dbb01d7859.png">
