### PR TITLE
External link styling

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -77,6 +77,8 @@
 		border-color: transparent;
 		overflow: hidden;
 		text-indent: -10000px;
+		text-align: left;
+		color: rgba(0,0,0,0);
 	}
 }
 

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -78,7 +78,7 @@
 		overflow: hidden;
 		text-indent: -10000px;
 		text-align: left;
-		color: rgba(0,0,0,0);
+		color: rgba(0, 0, 0, 0);
 	}
 }
 


### PR DESCRIPTION
- ensure hidden text is left-aligned in case parent link has text-align: right
- use transparent text