### PR TITLE
Fix whitelabel build before branding more completely.

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -40,10 +40,11 @@
 
 /// Standard link styles
 @mixin oTypographyLink {
-	@include oTypographyLinkCustom(
-		$baseColor: oColorsGetUseCase(link, text),
-		$hoverColor: 'teal-30'
-	);
+	$base-color: oColorsGetUseCase(link, text);
+	$hover-color: oColorsGetUseCase(link-hover, text);
+	@if $base-color and $hover-color {
+		@include oTypographyLinkCustom($base-color, $hover-color);
+	}
 }
 
 /// Standard link styles + external link icon.


### PR DESCRIPTION
Whitelabel demos are failing as `o-typography` has not been branded. This is a quick fix to allow `o-typography` to build. 

In addition, it updates the link mixin to use an `o-colors` usecase for the hover state. **Must not be merged before the [color usecase is correct](https://github.com/Financial-Times/o-colors/pull/166).**