### PR TITLE
Do not register custom font via o-typography.

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,19 +297,13 @@ If you need to cap the line width, o-typography provides a function which limits
 
 ### Use A Custom Font
 
-To use a custom font with `o-typography` set the custom font using `oTypographySetCustomFont` before calling any other `o-typography` mixins. It accepts a family style (sans, serif, or display), the custom font family, and the variants the fonts supports (which are combinations of weight and style).
+To set a custom font, [first register the font using o-fonts](https://registry.origami.ft.com/components/o-fonts).
+
+Then set the custom font using `oTypographySetFont` before calling any other `o-typography` mixins. It accepts a font type (sans, serif, or display) and the custom font family.
 
 ```scss
-	@import 'o-typography/main';
-	// Set custom sans font, with support for regular and bold weights.
- 	@include oTypographySetCustomFont(
-		$family-style: 'sans',
-		$family: 'MySansFont, sans',
-		$variants: (
- 			(weight: regular, style: normal),
- 			(weight: bold, style: normal)
-		)
-	);
+	// Set custom sans font.
+ 	@include oTypographySetFont($type: 'sans', $family: 'MySansFont, sans');
 	// The custom sans font is now output by other `o-typography` mixins such as `oTypography`.
 	@include oTypography();
 ```

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -31,7 +31,7 @@
             'blockquote-color': oColorsGetPaletteColor('claret'),
             'custom-link-focus-outline-color': oColorsGetPaletteColor('teal-100'), //deprecated
             'heading-level-one-large': (
-                'family-style': 'display',
+                'font-type': 'display',
                 'weight': 'bold',
                 'bottom-spacing-size': 7,
                 'scale': 5,
@@ -39,7 +39,7 @@
                 'scale-l': 7,
             ),
             'heading-level-one': (
-                'family-style': 'display',
+                'font-type': 'display',
                 'scale': 4,
                 'scale-s': 5,
                 'scale-l': 6,
@@ -60,7 +60,7 @@
                 'letter-spacing': 0.5px
             ),
             'body': (
-                'family-style': 'serif',
+                'font-type': 'serif',
                 'bottom-spacing-size': 7,
                 'custom-line-height': 28px,
             )

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -72,20 +72,19 @@
 /// 	font-family: oTypographyGetFamily('sans')
 ///
 /// @access private
-/// @param {String} $family-style - One of 'sans', 'serif', or 'display'.
+/// @param {String} $type - One of 'sans', 'serif', or 'display'.
 /// @return {String|List} The font-family set for the given font style.
-@function _oTypographyFontFamilyForStyle($family-style) {
-	$family-styles: ('sans', 'serif', 'display');
-	@if not index($family-styles, $family-style) {
-		@error 'Could not get the font-family for font of style "#{$family-style}", style must be one of "#{$family-styles}".';
+@function _oTypographyFontFamilyForType($type) {
+	@if not index($_o-typography-types, $type) {
+		@error 'Could not get the font-family for font of style "#{$type}", style must be one of "#{$_o-typography-types}".';
 	}
-	@if $family-style == 'sans' {
+	@if $type == 'sans' {
 		@return $o-typography-sans;
 	}
-	@if $family-style == 'serif' {
+	@if $type == 'serif' {
 		@return $o-typography-serif;
 	}
-	@if $family-style == 'display' {
+	@if $type == 'display' {
 		@return $o-typography-display;
 	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -77,30 +77,27 @@
 
 /// Set a custom font.
 ///
-/// @example This example shows setting a custom font "MySansFont" as the "sans" font. We specify out custom font supports regular or bold variants.
-/// 	@include oTypographySetCustomFont($family-style: 'sans', $family: 'MySansFont, sans', $variants: (
-/// 		(weight: regular, style: normal),
-/// 		(weight: bold, style: normal)
-/// 	));
+/// @example This example shows setting a custom font "MySansFont" as the "sans" font.
+/// 	@include oTypographySetFont($type: 'sans', $family: 'MySansFont, sans');
 ///
-/// @param {String} $family-style - One of 'sans', 'serif', or 'display'.
+/// @param {String} $type - One of 'sans', 'serif', or 'display'.
 /// @param {String} $family - The font family to set.
-/// @param {Map} $variants - The variants (weight and style combinations) which are allowed in a nested map.
-@mixin oTypographySetCustomFont($family-style, $family, $variants) {
-	$family-styles: ('sans', 'serif', 'display');
-	@if not index($family-styles, $family-style) {
-		@error 'Could not set font-family "#{$family}" for family style "#{$family-style}", family style must be one of "#{$family-styles}".';
+@mixin oTypographySetFont($type, $family) {
+	$font: oFontsGetFontFamilyWithoutFallbacks($family);
+	@if not oFontsVariantExists($font, $weight: null, $style: null) {
+		@error 'Could not set the font family "#{$family}" as "#{$font}" does not exist in "o-fonts". If you are setting a custom font, first register your custom font with o-fonts (https://registry.origami.ft.com/components/o-fonts).';
 	}
-	// Register the custom font with o-fonts.
-	@include oFontsDefineCustomFont($family, $variants);
+	@if not index($_o-typography-types, $type) {
+		@error 'Could not set font-family "#{$family}" for family style "#{$type}", family style must be one of "#{$_o-typography-types}".';
+	}
 	// Set the custom font.
-	@if $family-style == 'sans' {
+	@if $type == 'sans' {
 		$o-typography-sans: $family !global;
 	}
-	@if $family-style == 'serif' {
+	@if $type == 'serif' {
 		$o-typography-serif: $family !global;
 	}
-	@if $family-style == 'display' {
+	@if $type == 'display' {
 		$o-typography-display: $family !global;
 	}
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -53,6 +53,10 @@ $o-typography-font-scale: (
    10: (84, 84),
 ) !default;
 
+/// The "types" of fonts o-typography supports.
+/// @access private
+$_o-typography-types: ('sans', 'serif', 'display');
+
 /// Font scale of font-sizes and line-heights.
 /// Currently the default scale `$o-typography-font-scale` is used for all fonts and brands,
 /// but branded products may choose to define their own scale on a per font basis.

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -6,9 +6,9 @@
 /// Body text styles
 @mixin oTypographyBody {
 	// If family style is not given default to sans.
-	$family-style: _oTypographyGet('family-style', 'body');
-	$family-style: if($family-style, $family-style, 'sans');
-	$font-family: _oTypographyFontFamilyForStyle($family-style);
+	$type: _oTypographyGet('font-type', 'body');
+	$type: if($type, $type, 'sans');
+	$font-family: _oTypographyFontFamilyForType($type);
 	// If scale isn't given default to 1.
 	$scale: _oTypographyGet('scale', 'body');
 	$scale: if($scale, $scale, 1);
@@ -142,9 +142,9 @@
 	@include oTypographyMargin($top: 0, $bottom: 7);
 
 	li {
-		$family-style: _oTypographyGet('family-style', 'body');
-		$family-style: if($family-style, $family-style, 'sans');
-		$font-family: _oTypographyFontFamilyForStyle($family-style);
+		$type: _oTypographyGet('font-type', 'body');
+		$type: if($type, $type, 'sans');
+		$font-family: _oTypographyFontFamilyForType($type);
 		@include _oTypographyFor($font-family, $opts: (
 			'family': true,
 			'scale': 1,

--- a/src/scss/use-cases/_headings.scss
+++ b/src/scss/use-cases/_headings.scss
@@ -57,9 +57,9 @@
 /// @access private
 @mixin _oTypographyHeading($from) {
 	// If family style is not given default to sans.
-	$family-style: _oTypographyGet('family-style', $from);
-	$family-style: if($family-style, $family-style, 'sans');
-	$font-family: _oTypographyFontFamilyForStyle($family-style);
+	$type: _oTypographyGet('font-type', $from);
+	$type: if($type, $type, 'sans');
+	$font-family: _oTypographyFontFamilyForType($type);
 	// If weight is not given default to regular, overriding the browser default.
 	$weight: _oTypographyGet('weight', $from);
 	$weight: if($weight, $weight, 'regular');

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -28,40 +28,31 @@
 	}
 }
 
-@include test-module('oTypographySetCustomFont') {
+@include test-module('oTypographySetFont') {
 	@include test('Updates the global variable for the sans font') {
-        @include oTypographySetCustomFont(
-            $family-style: 'sans',
-            $family: 'system-ui',
-            $variants: (
-                (weight: semibold, style: normal),
-                (weight: regular, style: normal),
-                (weight: bold, style: normal)
-            )
+        @include oFontsDefineCustomFont('system-ui', (
+            (weight: semibold, style: normal),
+            (weight: regular, style: normal),
+            (weight: bold, style: normal)
+        ));
+        // Set sans font.
+        @include oTypographySetFont(
+            $type: 'sans',
+            $family: 'system-ui'
         );
         @include assert-equal($o-typography-sans, 'system-ui');
 	}
-	@include test('Updates the global variable for the serif font') {
-        @include oTypographySetCustomFont(
-            $family-style: 'serif',
-            $family: 'MySerifFont, serif',
-            $variants: (
-                (weight: semibold, style: normal),
-                (weight: regular, style: normal),
-                (weight: bold, style: normal)
-            )
-        );
-        @include assert-equal($o-typography-serif, 'MySerifFont, serif');
-	}
+
 	@include test('Updates the global variable for the display font') {
-        @include oTypographySetCustomFont(
-            $family-style: 'display',
-            $family: 'MyDisplayFont',
-            $variants: (
-                (weight: semibold, style: normal),
-                (weight: regular, style: normal),
-                (weight: bold, style: normal)
-            )
+        @include oFontsDefineCustomFont('MyDisplayFont, serif', (
+            (weight: semibold, style: normal),
+            (weight: regular, style: normal),
+            (weight: bold, style: normal)
+        ));
+        // Set display font.
+        @include oTypographySetFont(
+            $type: 'display',
+            $family: 'MyDisplayFont'
         );
         @include assert-equal($o-typography-display, 'MyDisplayFont');
 	}


### PR DESCRIPTION
We decided for the v5.8.0 release **not** to use a custom font like:

```scss
// Use Roboto for the sans font.
$roboto-family: 'Roboto, sans-serif';
@include oTypographySetCustomFont(
    $family-style: 'sans',
    $family: $roboto-family,
    $variants: (
        (weight: regular, style: normal),
        (weight: semibold, style: normal),
        (weight: bold, style: normal)
    )
);

// Define a custom font scale for Roboto.
@include oTypographyDefineFontScale(
    $family: $roboto-family,
    $scale: (
        -2: (12, (12 * 1.3)),
        -1: (14, (14 * 1.3)),
         0: (16, (16 * 1.3)),
         1: (18, (18 * 1.3)),
         2: (20, (20 * 1.3)),
         3: (24, (24 * 1.3)),
         4: (28, (28 * 1.3)),
         5: (32, (32 * 1.3)),
         6: (40, (40 * 1.3)),
         7: (48, (48 * 1.3)),
         8: (56, (56 * 1.3)),
         9: (72, (72 * 1.3)),
        10: (84, (84 * 1.3))
));
```

And **instead** to:

```scss
// Add Roboto font.
$roboto-family: 'Roboto, sans-serif';
@include oFontsDefineCustomFont($roboto-family, (
    (weight: regular, style: normal),
    (weight: bold, style: normal)
));

// Use Roboto font for typography.
@include oTypographySetFont(
    $type: 'sans',
    $family: $roboto-family
);

// Define a custom font scale for Roboto.
@include oTypographyDefineFontScale(
    $family: $roboto-family,
    $scale: (
        -2: (12, (12 * 1.3)),
        -1: (14, (14 * 1.3)),
         0: (16, (16 * 1.3)),
         1: (18, (18 * 1.3)),
         2: (20, (20 * 1.3)),
         3: (24, (24 * 1.3)),
         4: (28, (28 * 1.3)),
         5: (32, (32 * 1.3)),
         6: (40, (40 * 1.3)),
         7: (48, (48 * 1.3)),
         8: (56, (56 * 1.3)),
         9: (72, (72 * 1.3)),
        10: (84, (84 * 1.3))
));
```

As you could set a font in `o-typography` that already exists in `o-fonts`.