### PR TITLE
Support relatively sized typography behide a flag.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -18,7 +18,7 @@
 /// @returns {Number} size in px
 @function _oTypographyFontSizeFromScale($scale, $font-adjust: 1, $font: '') {
 	$settings: oTypographyGetScale($scale, $font);
-	@return (nth($settings, 1) * $font-adjust) * 1px;
+	@return _oTypographyAddUnit(nth($settings, 1) * $font-adjust);
 }
 
 /// Returns the line-height value from the scale passed in or
@@ -32,10 +32,10 @@
 	$settings: oTypographyGetScale($scale, $font);
 
 	@if $line-height {
-		@return $line-height;
+		@return _oTypographyCorrectUnit($line-height);
 	} @else {
 		$line-height: nth($settings, 2);
-		@return if($line-height, $line-height * 1px, null);
+		@return if($line-height, _oTypographyAddUnit($line-height), null);
 	}
 }
 
@@ -45,7 +45,7 @@
 /// @param {Number} $units [0] - multiple of the baseline unit
 /// @returns {Number} size in px
 @function oTypographySpacingSize($units: 0) {
-	@return ($units * $o-typography-baseline-unit) * 1px;
+	@return _oTypographyAddUnit($units * $o-typography-baseline-unit);
 }
 
 /// Returns a maximum line width based on the given scale
@@ -57,8 +57,8 @@
 @function oTypographyMaxLineWidth($scale: 0, $optimal-characters-per-line: 65, $font: '') {
 	$settings: oTypographyGetScale($scale, $font);
 
-	$font-size: nth($settings, 1) * 1px;
-	$line-height: if(nth($settings, 2), nth($settings, 2) * 1px, $font-size);
+	$font-size: _oTypographyAddUnit(nth($settings, 1));
+	$line-height: if(nth($settings, 2), _oTypographyAddUnit(nth($settings, 2)), $font-size);
 
 	$golden-ratio: 1.618;
 	$scale-ratio: ($font-size / $line-height)  + $golden-ratio; //adapts ratio to quirks in oTypography's line-heights
@@ -87,4 +87,27 @@
 	@if $type == 'display' {
 		@return $o-typography-display;
 	}
+}
+
+/// Changes a px value to a rem value if relative units are enabled.
+/// Useful for user input such as custom line-heights, where a px value
+/// should become a rem value but otherwise the value should remain unchanged.
+/// @access private
+/// @param {Number} $value
+@function _oTypographyCorrectUnit($value) {
+	@if ($o-typography-relative-units and unit($value) == 'px') {
+		@return (($value / 1px) / 16) * 1rem;
+	}
+	@return $value;
+}
+
+/// Adds a px unit to a unitless pixel value, or converts to a rem unit if relative units are enabled.
+/// Useful as the public typographic scales are currently defined in px but unitless.
+/// @access private
+/// @param {Number} $value
+@function _oTypographyAddUnit($value) {
+	@if ($o-typography-relative-units) {
+		@return ($value / 16) * 1rem;
+	}
+	@return $value * 1px;
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -11,7 +11,7 @@
 			@if $breakpoint == 'default' {
 				@if type-of($scale) == list {
 					font-size: _oTypographyFontSizeFromScale(nth($scale, 1), 1, $font);
-					line-height: nth($scale, 2);
+					line-height: _oTypographyLineHeightFromScale($scale, $font);
 				} @else {
 					font-size: _oTypographyFontSizeFromScale($scale, 1, $font);
 					line-height: _oTypographyLineHeightFromScale($scale, $line-height, $font);
@@ -20,7 +20,7 @@
 				@include oGridRespondTo($breakpoint) {
 					@if type-of($scale) == list {
 						font-size: _oTypographyFontSizeFromScale(nth($scale, 1), 1, $font);
-						line-height: nth($scale, 2);
+						line-height: _oTypographyLineHeightFromScale($scale, $font);
 					} @else {
 						font-size: _oTypographyFontSizeFromScale($scale, 1, $font);
 						line-height: _oTypographyLineHeightFromScale($scale, $line-height, $font);

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -135,7 +135,7 @@
 	@if $scale {
 		@include oTypographySize($scale: $scale, $line-height: $custom-line-height, $font: $font);
 	} @else if $custom-line-height {
-		line-height: $custom-line-height;
+		line-height: _oTypographyCorrectUnit($custom-line-height);
 	}
 
 	@if $weight  {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -2,6 +2,14 @@
 /// @type Bool
 $o-typography-is-silent: true !default;
 
+/// Use relative units (rem) or not (px) when outputting typographic styles.
+/// When `true`, the user will be able to modify their font size using browser settings.
+///
+/// For legacy reasons, this defaults to `false` (outputs px units).
+/// Components and projects may need to be updated to support relative units.
+/// @type Bool
+$o-typography-relative-units: true !default;
+
 /// When true, webfonts will be downloaded
 /// @type Bool
 $o-typography-load-fonts: true !default;


### PR DESCRIPTION
FT sites which use Origami don't respect browser font size settings. Which means our sites can't adapt as well to the device they are display on, or to user preferences (hindering accessibly).

It's hard to change that as components and products have come to expect certain px values and are hardcoded for it (e.g. to align elements with a set number of px values). With a major coming to `o-typography`, we have an opportunity to change that and improve many FT sites 🎉 

This non-breaking PR adds support for relative font units, but it is disabled by default. Therefore products and components can be updated over time to support relative font units. We can consider turning relative units on by default in the next major

This was quickly thrown together at the end of the day, before a long weekend 😬
But I actually think it's quite solid 😀 🎉 

**Chrome font size setting.**
<img width="717" alt="screenshot 2018-12-06 at 18 26 22" src="https://user-images.githubusercontent.com/10405691/49605092-8873ed00-f987-11e8-85fb-e9d193b63f26.png">

**Left (current, browser font size not respected / Right (now, browser font size respected)**
<img width="1440" alt="screenshot 2018-12-06 at 18 39 10" src="https://user-images.githubusercontent.com/10405691/49605110-91fd5500-f987-11e8-9f65-18cc1f3f0499.png">
