### PR TITLE
Fix custom line heights for "oTypographySize".

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,22 +216,36 @@ See more type mixins in the registry [SassDoc documentation](sassdoc).
 
 If you want to output only the font-size and line-height from the font scale, you can use the `oTypographySize` mixin.
 
-Example:
-
 ```scss
 .example {
 	@include oTypographySize($scale: 8);
 }
 ```
 
-As with the [type mixins](#type-mixins), the `oTypographySize` mixin can accept a map for a responsive scale. It can also accept a second parameter of `$line-height` to override the default value from the font scale.
+It can also accept a second parameter of `$line-height` to override the default value from the font scale.
+
+```scss
+.example {
+	@include oTypographySize($scale: 8, $line-height: 1.4);
+}
+```
+
+As with the [type mixins](#type-mixins), the `oTypographySize` mixin can accept a map for a responsive scale.
 
 ```scss
 .example {
 	@include oTypographySize($scale: (default: 0, M: 1, XL: 2));
 }
 ```
-g
+
+To provide a custom line height for each individual breakpoint pass the scale as a list, where the custom line height is the second item. In this example the scale is `0` and line-height is `1.4` by default. On large `XL` screens the scale is `2` and the line-height is `1.2`.
+
+```scss
+.example {
+	@include oTypographySize($scale: (default: (0, 1.4), XL: (2, 1.2)));
+}
+```
+
 ### Spacing
 
 Along with font sizing o-typography provides spacing mixins, for spacing elements within a baseline grid. The baseline grid defaults to `4px`, stored in `$o-typography-baseline-unit`.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -5,26 +5,21 @@
 /// @param {Number} $scale number on scale the sizes are based on
 /// @param {Bool | Number} $line-height size to override the line-height property
 /// @param {String} $font [''] - The font to get the font size for, as fonts may have different scales. Uses the default scale if not specified.
-@mixin oTypographySize($scale, $line-height: false, $font: '') {
+@mixin oTypographySize($scale, $line-height: false, $font: '', $error: false) {
 	@if type-of($scale) == map {
 		@each $breakpoint, $scale in $scale {
-			@if $breakpoint == 'default' {
-				@if type-of($scale) == list {
-					font-size: _oTypographyFontSizeFromScale(nth($scale, 1), 1, $font);
-					line-height: _oTypographyLineHeightFromScale($scale, $font);
-				} @else {
-					font-size: _oTypographyFontSizeFromScale($scale, 1, $font);
-					line-height: _oTypographyLineHeightFromScale($scale, $line-height, $font);
-				}
-			} @else if($scale) {
+			$current-line-height: if(length($scale) == 2, nth($scale, 2), $line-height);
+			$current-scale: if(type-of($scale) == list and length($scale) != 0, nth($scale, 1), $scale);
+
+			@if $breakpoint == 'default' and $current-scale {
+				font-size: _oTypographyFontSizeFromScale($current-scale, 1, $font);
+				line-height: _oTypographyLineHeightFromScale($current-scale, $current-line-height, $font);
+			}
+
+			@if $breakpoint != 'default' and $current-scale {
 				@include oGridRespondTo($breakpoint) {
-					@if type-of($scale) == list {
-						font-size: _oTypographyFontSizeFromScale(nth($scale, 1), 1, $font);
-						line-height: _oTypographyLineHeightFromScale($scale, $font);
-					} @else {
-						font-size: _oTypographyFontSizeFromScale($scale, 1, $font);
-						line-height: _oTypographyLineHeightFromScale($scale, $line-height, $font);
-					}
+					font-size: _oTypographyFontSizeFromScale($current-scale, 1, $font);
+					line-height: _oTypographyLineHeightFromScale($current-scale, $current-line-height, $font);
 				}
 			}
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -5,7 +5,7 @@
 /// @param {Number} $scale number on scale the sizes are based on
 /// @param {Bool | Number} $line-height size to override the line-height property
 /// @param {String} $font [''] - The font to get the font size for, as fonts may have different scales. Uses the default scale if not specified.
-@mixin oTypographySize($scale, $line-height: false, $font: '', $error: false) {
+@mixin oTypographySize($scale, $line-height: false, $font: '') {
 	@if type-of($scale) == map {
 		@each $breakpoint, $scale in $scale {
 			$current-line-height: if(length($scale) == 2, nth($scale, 2), $line-height);

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -57,3 +57,98 @@
         @include assert-equal($o-typography-display, 'MyDisplayFont');
 	}
 }
+
+
+@include test-module('oTypographySize') {
+	@include test('Includes a font size and line height for a given scale.') {
+        @include assert {
+            @include output {
+                @include oTypographySize($scale: 1);
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 20px;
+            }
+        }
+    }
+
+	@include test('Includes a font size and line height for a given responsive scale.') {
+        @include assert {
+            @include output {
+                @include oTypographySize($scale: (default: 1, L: 2));
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 20px;
+
+                @media (min-width: 61.25em) {
+                    font-size: 20px;
+                    line-height: 24px;
+                }
+            }
+        }
+    }
+
+	@include test('Includes a custom line height for a given scale.') {
+        @include assert {
+            @include output {
+                @include oTypographySize($scale: 1, $line-height: 1.4);
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 1.4;
+            }
+        }
+    }
+
+	@include test('Includes a custom line height for a responsive scale.') {
+        @include assert {
+            @include output {
+                @include oTypographySize($scale: (default: 1, L: 2), $line-height: 24px);
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 24px;
+
+                @media (min-width: 61.25em) {
+                    font-size: 20px;
+                    line-height: 24px;
+                }
+            }
+        }
+    }
+
+	@include test('Includes seperate custom line heights for each scale in a responsive scale.') {
+        @include assert {
+            @include output {
+                @include oTypographySize($scale: (default: (1, 18px), L: (2, 24px)));
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 18px;
+
+                @media (min-width: 61.25em) {
+                    font-size: 20px;
+                    line-height: 24px;
+                }
+            }
+        }
+    }
+
+	@include test('Priorities custom line heights in responsive scales.') {
+        @include assert {
+            @include output {
+                @include oTypographySize($scale: (default: (1, 18px), L: 2), $line-height: 1.4);
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 18px;
+
+                @media (min-width: 61.25em) {
+                    font-size: 20px;
+                    line-height: 1.4;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Custom line heights in responsive typography is not output. E.g this is effecting the topper, which is a :
```scss
@include oTypographySize($scale: (default: (-1, 22px), L: (0, 24px)));
```
https://github.com/Financial-Times/o-teaser/blob/master/src/scss/elements/_related-items.scss#L15

<img width="591" alt="screenshot 2019-01-18 at 12 59 21" src="https://user-images.githubusercontent.com/10405691/51388323-f3851780-1b20-11e9-87c3-6f5260b3b2b4.png">
