### PR TITLE
Support whitelabel brand customisation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,9 +359,11 @@ With `oTypographyCustomize` you can change the size of heading levels and update
 $o-brand: whitelabel;
 @import 'o-typography/main';
 
-// 1. Set a custom font (see "Use A Custom Font").
+// 1. Set a custom font.
+// See "Use A Custom Font".
 
-// 2. Set a custom typographic scale (see "Use A Custom Font Scale").
+// 2. Set a custom typographic scale.
+// See "Use A Custom Font Scale".
 
 // 3. Customise typography variants.
 @include oTypographyCustomize((

--- a/README.md
+++ b/README.md
@@ -349,6 +349,51 @@ $example-custom-font-scale: (
 @include oTypographyDefineFontScale($example-custom-font-family, $example-custom-font-scale);
 ```
 
+### Customisation
+
+`o-typography` provides mixins to [set a custom font](#use-a-custom-font) and a [custom font scale](#use-a-custom-font-scale). If your project uses the `whitelabel` brand, `o-typography` provides the option to customise typography further with the `oTypographyCustomize` mixin.
+
+With `oTypographyCustomize` you can change the size of heading levels and update the colour of `o-typography`'s blockquote. In the below example, we update the size of `h1` and `h2` headings, and change the blockquote colour to `hotpink`. For a full list of brand variables which may be customised, see the [oTypographyCustomize SassDoc](https://registry.origami.ft.com/components/o-typography/sassdoc?brand=whitelabel#mixin-oTypographyCustomize).
+
+```scss
+$o-brand: whitelabel;
+@import 'o-typography/main';
+
+// 1. Set a custom font (see "Use A Custom Font").
+
+// 2. Set a custom typographic scale (see "Use A Custom Font Scale").
+
+// 3. Customise typography variants.
+@include oTypographyCustomize((
+    'blockquote-color': hotpink, // Update the blockquote border color to hotpink.
+    'heading-level-one': (
+        'scale': 7, // Update the size of h1.
+    ),
+    'heading-level-two': (
+        'scale': 6 // Update the size of h2 (up to h6 is supported heading-level-six).
+    )
+));
+
+// 4. Output typography styles.
+h1 {
+	@include oTypographyHeadingLevel1();
+}
+
+h2 {
+	@include oTypographyHeadingLevel2();
+}
+
+blockquote {
+	p {
+		@include oTypographyBlockquote;
+	}
+
+	footer {
+		@include oTypographyFooter;
+	}
+}
+```
+
 ## JavaScript
 
 o-typography uses JavaScript to [progressively load fonts](#progressive-loading-web-fonts) to prevent a flash of invisible content (FOIC) if the web-fonts are taking a long time to load.

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -15,30 +15,30 @@
 /// @param {Map} $variables - Brand variables to customise
 /// @access public
 /// @example scss
-///		@include oTypographyCustomize((
-///         'blockquote-color': hotpink,
-///         'heading-level-one': (
-///             'scale': 7,
-///         ),
-///         'heading-level-two': (
-///             'scale': 6
-///         ),
-///         'heading-level-three': (
-///             'scale': 5
-///         ),
-///         'heading-level-four': (
-///             'scale': 4
-///         ),
-///         'heading-level-five': (
-///             'scale': 3
-///         ),
-///         'heading-level-six': (
-///             'scale': 2
-///         ),
-///         'body': (
-///             'bottom-spacing-size': 8,
-///         )
-///		))
+///    @include oTypographyCustomize((
+///        'blockquote-color': hotpink,
+///        'heading-level-one': (
+///            'scale': 7,
+///        ),
+///        'heading-level-two': (
+///            'scale': 6
+///        ),
+///        'heading-level-three': (
+///            'scale': 5
+///        ),
+///        'heading-level-four': (
+///            'scale': 4
+///        ),
+///        'heading-level-five': (
+///            'scale': 3
+///        ),
+///        'heading-level-six': (
+///            'scale': 2
+///        ),
+///        'body': (
+///            'bottom-spacing-size': 8,
+///        )
+//    ))
 @mixin oTypographyCustomize($variables) {
     // Only allow certain brand variables to be customised.
     $allowed-brand-variables: (

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -10,6 +10,57 @@
     @return oBrandSupportsVariant($component: 'o-typography', $variant: $variant);
 }
 
+/// Helper for `whitelabel` brand variable customisation.
+/// @brand whitelabel
+/// @param {Map} $variables - Brand variables to customise
+/// @access public
+/// @example scss
+///		@include oTypographyCustomize((
+///         'blockquote-color': hotpink,
+///         'heading-level-one': (
+///             'scale': 7,
+///         ),
+///         'heading-level-two': (
+///             'scale': 6
+///         ),
+///         'heading-level-three': (
+///             'scale': 5
+///         ),
+///         'heading-level-four': (
+///             'scale': 4
+///         ),
+///         'heading-level-five': (
+///             'scale': 3
+///         ),
+///         'heading-level-six': (
+///             'scale': 2
+///         ),
+///         'body': (
+///             'bottom-spacing-size': 8,
+///         )
+///		))
+@mixin oTypographyCustomize($variables) {
+    // Only allow certain brand variables to be customised.
+    $allowed-brand-variables: (
+        'blockquote-color',
+        'heading-level-one',
+        'heading-level-two',
+        'heading-level-three',
+        'heading-level-four',
+        'heading-level-five',
+        'heading-level-six',
+        'body',
+    );
+    @each $brand-variable in map-keys($variables) {
+        @if not index($allowed-brand-variables, $brand-variable) {
+            @error 'You cannot customise the brand variable "#{$brand-variable}". Did you mean one of: "#{$allowed-brand-variables}"? Please contact the Origami team if you need to customise something new.';
+        }
+    }
+    // Customise the brand.
+	@include oBrandCustomize('o-typography', $variables);
+}
+
+
 // Register Georgia font and allowed variants with `o-fonts`.
 // Shared by all brands.
 @include oFontsDefineCustomFont('Georgia, serif', (

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -57,7 +57,7 @@
         }
     }
     // Customise the brand.
-	@include oBrandCustomize('o-typography', $variables);
+    @include oBrandCustomize('o-typography', $variables);
 }
 
 

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -29,7 +29,7 @@
 @mixin oTypographySub {
 	@include oTypographySans(-2);
 	display: inline-block;
-	margin-bottom: -5px;
+	margin-bottom: _oTypographyAdjustUnit(-5px);
 	vertical-align: sub;
 }
 
@@ -37,7 +37,7 @@
 @mixin oTypographySuper {
 	@include oTypographySans(-2);
 	display: inline-block;
-	margin-top: -3px;
+	margin-top: _oTypographyAdjustUnit(-3px);
 	vertical-align: super;
 }
 

--- a/src/scss/use-cases/_headings.scss
+++ b/src/scss/use-cases/_headings.scss
@@ -48,7 +48,7 @@
 }
 
 /// Level 6 heading styles.
-/// @brand internal
+/// @brand internal|whitelabel
 @mixin oTypographyHeadingLevel6 {
 	@include _oTypographyHeading($from: 'heading-level-six');
 }


### PR DESCRIPTION
Adds support for changing header and body scales, and the blockquote colour.

Also snuck in a little change to `sub`/`sup`, so they use relative font units if relative font units are enabled.