### PR TITLE
Make the default "sans", "serif", or "display" bold font weight customisable

### DIFF
--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -35,9 +35,9 @@ $o-typography-display: '' !default;
 /// @example scss
 ///    @include oTypographyCustomize((
 ///        'blockquote-color': hotpink,
-///        'bold-weight': 'bold',
+///        'bold-level': 'bold',
 ///        'sans': (
-///            'bold-weight': 'semibold'
+///            'bold-level': 'semibold'
 ///        ),
 ///        'heading-level-one': (
 ///            'scale': 7,
@@ -103,9 +103,9 @@ $o-typography-display: '' !default;
             'author-hover-color': oColorsGetPaletteColor('claret'),
             'blockquote-color': oColorsGetPaletteColor('claret'),
             'custom-link-focus-outline-color': oColorsGetPaletteColor('teal-100'), //deprecated
-            'bold-weight': 'bold',
+            'bold-level': 'bold',
             'sans': (
-                'bold-weight': 'semibold' // override the default "bold" font weight for the sans font
+                'bold-level': 'semibold' // override the default "bold" font weight for the sans font
             ),
             'heading-level-one-large': (
                 'font-type': 'display',
@@ -163,7 +163,7 @@ $o-typography-display: '' !default;
         'variables': (
             'blockquote-color': oColorsGetColorFor(body, text),
             'custom-link-focus-outline-color': oColorsGetPaletteColor('teal-100'), //deprecated
-            'bold-weight': 'semibold',
+            'bold-level': 'semibold',
             'heading-level-one': (
                 'scale': 5,
                 'weight': 'semibold'
@@ -235,7 +235,7 @@ $o-typography-display: '' !default;
     @include oBrandDefine('o-typography', 'whitelabel', (
         'variables': (
             'blockquote-color': oColorsGetPaletteColor('black'),
-            'bold-weight': 'bold',
+            'bold-level': 'bold',
             'heading-level-one': (
                 'scale': 6,
             ),

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -60,7 +60,7 @@ $o-typography-display: '' !default;
 ///        'body': (
 ///            'bottom-spacing-size': 8,
 ///        )
-//    ))
+///    ));
 @mixin oTypographyCustomize($variables) {
     // Only allow certain brand variables to be customised.
     $allowed-brand-variables: (

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -35,6 +35,10 @@ $o-typography-display: '' !default;
 /// @example scss
 ///    @include oTypographyCustomize((
 ///        'blockquote-color': hotpink,
+///        'bold-weight': 'bold',
+///        'sans': (
+///            'bold-weight': 'semibold'
+///        ),
 ///        'heading-level-one': (
 ///            'scale': 7,
 ///        ),
@@ -99,6 +103,10 @@ $o-typography-display: '' !default;
             'author-hover-color': oColorsGetPaletteColor('claret'),
             'blockquote-color': oColorsGetPaletteColor('claret'),
             'custom-link-focus-outline-color': oColorsGetPaletteColor('teal-100'), //deprecated
+            'bold-weight': 'bold',
+            'sans': (
+                'bold-weight': 'semibold' // override the default "bold" font weight for the sans font
+            ),
             'heading-level-one-large': (
                 'font-type': 'display',
                 'weight': 'bold',
@@ -155,6 +163,7 @@ $o-typography-display: '' !default;
         'variables': (
             'blockquote-color': oColorsGetColorFor(body, text),
             'custom-link-focus-outline-color': oColorsGetPaletteColor('teal-100'), //deprecated
+            'bold-weight': 'semibold',
             'heading-level-one': (
                 'scale': 5,
                 'weight': 'semibold'
@@ -226,6 +235,7 @@ $o-typography-display: '' !default;
     @include oBrandDefine('o-typography', 'whitelabel', (
         'variables': (
             'blockquote-color': oColorsGetPaletteColor('black'),
+            'bold-weight': 'bold',
             'heading-level-one': (
                 'scale': 6,
             ),

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -94,7 +94,7 @@
 ///
 /// @access private
 /// @param {Bool | String} $font-type - the font type to style bold (i.e. 'sans', 'serif').
-/// @return {String} - The font weight to style the font type bold e.g. bold or semibold.
+/// @return {Null | Bool | String} - The font weight to style the font type bold e.g. bold or semibold. `false` or `null` is also accepted but deprecated.
 @function _oTypographyGetBoldWeight($font-type) {
 	$font-weight: _oTypographyGet('bold-weight', $from: $font-type);
 	$default-bold-weight: _oTypographyGet('bold-weight');

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -96,9 +96,9 @@
 /// @param {Bool | String} $font-type - the font type to style bold (i.e. 'sans', 'serif').
 /// @return {Null | Bool | String} - The font weight to style the font type bold e.g. bold or semibold. `false` or `null` is also accepted but deprecated.
 @function _oTypographyGetBoldWeight($font-type) {
-	$font-weight: _oTypographyGet('bold-weight', $from: $font-type);
-	$default-bold-weight: _oTypographyGet('bold-weight');
-	@return if($font-weight, $font-weight, $default-bold-weight);
+	$font-weight: _oTypographyGet('bold-level', $from: $font-type);
+	$default-bold-level: _oTypographyGet('bold-level');
+	@return if($font-weight, $font-weight, $default-bold-level);
 }
 
 /// Changes a px value to a rem value if relative units are enabled.

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -89,6 +89,18 @@
 	}
 }
 
+/// Get the configured font weight to display a font type "bold".
+/// Returns a weight e.g. bold or semibold.
+///
+/// @access private
+/// @param {Bool | String} $font-type - the font type to style bold (i.e. 'sans', 'serif').
+/// @return {String} - The font weight to style the font type bold e.g. bold or semibold.
+@function _oTypographyGetBoldWeight($font-type) {
+	$font-weight: _oTypographyGet('bold-weight', $from: $font-type);
+	$default-bold-weight: _oTypographyGet('bold-weight');
+	@return if($font-weight, $font-weight, $default-bold-weight);
+}
+
 /// Changes a px value to a rem value if relative units are enabled.
 /// Useful for user input such as custom line-heights, where a px value
 /// should become a rem value but otherwise the value should remain unchanged.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -68,7 +68,7 @@
 ///     .example-text--bold {
 ///     	@include oTypographyBold('sans');
 ///     }
-/// @param {Bool | String} $font [null] - the font type to style bold (i.e. 'sans', 'serif').
+/// @param {Bool | Null | String} $font [null] - the font type to style bold (i.e. 'sans', 'serif'). `false` or `null` is also accepted but deprecated.
 @mixin oTypographyBold($font: null) {
 	font-weight: oFontsWeight(_oTypographyGetBoldWeight($font-type: $font));
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -59,15 +59,18 @@
 	}
 }
 
-/// Outputs font-weight property for the given font
+/// Outputs font-weight property for the given font type.
 ///
-/// @param {Bool | String} $font [false] - font-family that is going to be styled bold
-@mixin oTypographyBold($font: false) {
-	@if $font == 'sans' {
-		font-weight: 600;
-	} @else {
-		font-weight: 700;
-	}
+/// @example Make a sans copy bold without outputting the font family again.
+///     .example-text {
+///     	@include oTypographySans($scale: 2);
+///     }
+///     .example-text--bold {
+///     	@include oTypographyBold('sans');
+///     }
+/// @param {Bool | String} $font [null] - the font type to style bold (i.e. 'sans', 'serif').
+@mixin oTypographyBold($font: null) {
+	font-weight: oFontsWeight(_oTypographyGetBoldWeight($font-type: $font));
 }
 
 /// Set a custom font.

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -54,7 +54,7 @@
 		'family': true,
 		'scale': $scale,
 		'custom-line-height': $line-height,
-		'weight': 'bold',
+		'weight': _oTypographyGetBoldWeight('display'),
 		'progressive': $progressive
 	));
 }
@@ -70,7 +70,7 @@
 		'family': true,
 		'scale': $scale,
 		'custom-line-height': $line-height,
-		'weight': 'semibold',
+		'weight': _oTypographyGetBoldWeight('sans'),
 		'progressive': $progressive
 	));
 }
@@ -86,7 +86,7 @@
 		'family': true,
 		'scale': $scale,
 		'custom-line-height': $line-height,
-		'weight': 'bold',
+		'weight': _oTypographyGetBoldWeight('serif'),
 		'progressive': $progressive
 	));
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -153,7 +153,6 @@
     }
 }
 
-
 @include test-module('oTypographyLinkExternalIcon') {
     @include test('Colours according to the link colour usecase by default.') {
         @include assert {
@@ -191,6 +190,88 @@
                 &::after {
                     background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:outside-page?source=o-icons&tint=%23FF0000,%23FF0000&format=svg");
                 }
+            }
+        }
+    }
+}
+
+@include test-module('oTypographyBold') {
+    @include test('Outputs the default font weight if not given a font type (the FinancierDisplayWeb bold weight for the master brand).') {
+        @include assert {
+            @include output {
+                @include oTypographyBold();
+            }
+            @include contains {
+                font-weight: 700;
+            }
+        }
+    }
+    @include test('Outputs the sans "bold" font weight of 600 (semibold).') {
+        @include assert {
+            @include output {
+                @include oTypographyBold('sans');
+            }
+            @include contains {
+                font-weight: 600;
+            }
+        }
+    }
+    @include test('Outputs the serif "bold" font weight.') {
+        @include assert {
+            @include output {
+                @include oTypographyBold('serif');
+            }
+            @include contains {
+                font-weight: 700;
+            }
+        }
+    }
+    @include test('Outputs the display "bold" font weight.') {
+        @include assert {
+            @include output {
+                @include oTypographyBold('display');
+            }
+            @include contains {
+                font-weight: 700;
+            }
+        }
+    }
+}
+
+@include test-module('oTypographySansBold') {
+    @include test('Outputs the sans "bold" font weight of 600 (semibold).') {
+        @include assert {
+            @include output {
+                @include oTypographySansBold($scale: 1);
+            }
+            @include contains {
+                font-weight: 600;
+            }
+        }
+    }
+}
+
+@include test-module('oTypographySerifBold') {
+    @include test('Outputs the serif "bold" font weight of 700 (bold).') {
+        @include assert {
+            @include output {
+                @include oTypographySerifBold($scale: 1);
+            }
+            @include contains {
+                font-weight: 700;
+            }
+        }
+    }
+}
+
+@include test-module('oTypographyDisplayBold') {
+    @include test('Outputs the display "bold" font weight of 700 (bold).') {
+        @include assert {
+            @include output {
+                @include oTypographyDisplayBold($scale: 1);
+            }
+            @include contains {
+                font-weight: 700;
             }
         }
     }


### PR DESCRIPTION
**background**
We have mixins such as `oTypographyBold('sans')` and `oTypographySansBold()`
to output the correct `font-weight` for strong copy. These mixins are useful as some 
fonts may only support "semibold" or "bold" weights, and we don't want to 
accidentally mix and match font-weights. However these mixins were created 
before branding and these weights were not customisable.

**new feature**
This PR makes "bold" font weights customisable by adding a 'bold-weight' brand 
variable. It may be set to "bold" or "semibold" according to the fonts a brand is 
using. Variants of the font type 'sans', 'serif', 'display' may be used to modify the
font weight for a font type within a brand (see the master brand brand config as 
an example).
```scss
@include oTypographyCustomize((
    'bold-weight': 'bold',
    'sans': (
        'bold-weight': 'semibold'
    ),
));
```

This is very likely to change in the next major but I think it's the best
approach without a breaking change.

**bug fix?**
`oTypographyBold` defaulted to the weight of the serif font i.e. "FinancierDisplayWeb". 
This means our internal products, which don't often if at all use the serif font, are likely 
to be using the wrong font weight for Metric. This is true for users of o-layout for 
example. Using branding the weight output by `oTypographyBold` now defaults to the 
`sans` font weight for the internal and whitelabel brands.

That said -- maybe we do want that for internal tools / products? I'll ask design about this 💅 

Bold Before / Bold After / Regular
<img width="469" alt="Screenshot 2019-04-05 at 16 33 38" src="https://user-images.githubusercontent.com/10405691/55639122-95cba780-57c0-11e9-90e8-f034bdd9b40e.png">
