### PR TITLE
Allow an un-ordered list within an ordered list.

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -166,7 +166,7 @@
 	:root & {
 		counter-reset: item;
 
-		li {
+		> li {
 			display: block;
 			position: relative;
 			padding-left: oTypographySpacingSize($units: 6);


### PR DESCRIPTION
And nested ordered lists.

As reported in `#ft-origami`:
![Screen Shot 2019-04-30 at 10 36 24](https://user-images.githubusercontent.com/10405691/56964723-a9fe8c80-6b53-11e9-9d9d-04c3f0357c88.png)
