### PR TITLE
Handle non-numeric values when relative units are enabled.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -105,8 +105,12 @@
 /// Useful for user input such as custom line-heights, where a px value
 /// should become a rem value but otherwise the value should remain unchanged.
 /// @access private
-/// @param {Number} $value
+/// @param {Number|String} $value - Any none numbers are returned as is (e.g. "unset")
 @function _oTypographyAdjustUnit($value) {
+	@if(type-of($value) != 'number') {
+		@return $value;
+	}
+
 	@if ($o-typography-relative-units and unit($value) == 'px') {
 		@return (($value / 1px) / 16) * 1rem;
 	}

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -151,6 +151,34 @@
             }
         }
     }
+
+    @include test('Outputs rem units when relative units are enabled.') {
+        @include assert {
+            @include output {
+                $o-typography-relative-units: true !global;
+                @include oTypographySize($scale: 1);
+                $o-typography-relative-units: false !global;
+            }
+            @include expect {
+                font-size: 1.125rem;
+                line-height: 1.25rem;
+            }
+        }
+    }
+
+    @include test('Outputs a custom line height "unset" when relative units are enabled.') {
+        @include assert {
+            @include output {
+                $o-typography-relative-units: true !global;
+                @include oTypographySize($scale: 1, $line-height: unset);
+                $o-typography-relative-units: false !global;
+            }
+            @include expect {
+                font-size: 1.125rem;
+                line-height: unset;
+            }
+        }
+    }
 }
 
 @include test-module('oTypographyLinkExternalIcon') {


### PR DESCRIPTION
E.g. `@include oTypographySize($scale: -1, $line-height: unset);`
should set a line height of 'unset', without trying to convert
'unset' to rems (and erroring).

Relates to: https://github.com/Financial-Times/o-forms/pull/261#pullrequestreview-233463697