### PR TITLE
Remove margins from p tags inside li tags

### DIFF
--- a/demos/src/lists.mustache
+++ b/demos/src/lists.mustache
@@ -1,9 +1,9 @@
 <ul class="o-typography-list o-typography-list--unordered">
-	<li>List</li>
+	<li><p>List</p></li>
 	<li>List</li>
 </ul>
 
 <ol class="o-typography-list o-typography-list--ordered">
 	<li>List ordered</li>
-	<li>List ordered</li>
+	<li><p>List ordered</p></li>
 </ol>

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -154,6 +154,10 @@
 		));
 		@include oTypographyMargin($top: 0, $bottom: 0);
 		color: oColorsGetColorFor('body', 'text');
+
+		> p {
+			@include oTypographyMargin($top: 0, $bottom: 0);
+		}
 	}
 }
 


### PR DESCRIPTION
In spark, it might be possible to have paragraph tags inside list tags.
This change removes the paragraph margins, so that the list styles
remain normal.

This is a pretty niche change, and in theory we could try and prevent this happening at source. But given it's valid HTML, it should be pretty harmless?

Before:
![Screenshot 2019-06-07 at 12 01 52](https://user-images.githubusercontent.com/1978880/59099837-39018000-891c-11e9-9f9c-22f2fe6102a6.png)

After: 
![Screenshot 2019-06-07 at 12 01 08](https://user-images.githubusercontent.com/1978880/59099847-3c950700-891c-11e9-968c-e4c70f4d76e8.png)
