### PR TITLE
Remove weight and style mixins.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,15 @@
 
 ### Migrating from v5 to v6
 
+The following mixins have been replaced:
+- oTypographySansBold: oTypographySans($weight: 'semibold')
+- oTypographyDisplayBold: oTypographyDisplay($weight: 'bold')
+- oTypographySerifBold: oTypographySerif($weight: 'bold')
+- oTypographySerifItalic: oTypographySerif($style: 'italic')
+- oTypographyBold('sans'): oTypographySans($weight: 'semibold', $opts: ('font-family': false))
+- oTypographyBold('serif'): oTypographySerif($weight: 'bold', $opts: ('font-family': false))
+- oTypographyItalic: Use the `$style` argument of other mixins. Eg. `oTypographySerif($style: 'italic')`.
+
 ### Editorial Typography
 
 Editorial typography, such as that used in article pages, has moved to a new component [o-editorial-typography](https://registry.origami.ft.com/components/o-editorial-typography).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,8 @@
 
 ### Migrating from v5 to v6
 
+The class `o-typography--loading-sansBold` is now `o-typography--loading-sans-bold` and `o-typography--loading-displayBold` is now `o-typography--loading-display-bold`.
+
 The following mixins have been replaced:
 - oTypographySansBold: oTypographySans($weight: 'semibold')
 - oTypographyDisplayBold: oTypographyDisplay($weight: 'bold')

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ p {
 Include both the CSS and JavaScript for o-typography in your project. While ensuring you have the loading classes for each font you wish to load on your html element:
 
 ```html
-<html class="o-typography--loading-sans o-typography--loading-sansBold o-typography--loading-display o-typography--loading-displayBold">
+<html class="o-typography--loading-sans o-typography--loading-sans-bold o-typography--loading-display o-typography--loading-display-bold">
 ```
 
 If you build your projects using Sass, styles for progressively loading fonts are output by default when using the [use case mixins](#use-case-mixins) or [type mixins](#type-mixins).

--- a/main.scss
+++ b/main.scss
@@ -67,11 +67,14 @@
 	// Body, Links, Lists, etc.
 	@if $utilities-enabled {
 		.o-typography-bold {
-			@include oTypographyBold;
+			@include oTypographySans (
+				$weight: 'semibold',
+				$opts: ('font-family': false)
+			);
 		}
 
 		.o-typography-italic {
-			@include oTypographyItalic;
+			font-style: italic;
 		}
 
 		.o-typography-sup {

--- a/origami.json
+++ b/origami.json
@@ -24,7 +24,7 @@
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
 		"dependencies": ["o-grid@^4.0.0", "o-normalise@^1.0.0"],
-		"documentClasses": "o-grid-container o-typography--loading-display o-typography--loading-sans o-typography--loading-sansBold o-typography--loading-displayBold"
+		"documentClasses": "o-grid-container o-typography--loading-display o-typography--loading-sans o-typography--loading-sans-bold o-typography--loading-display-bold"
 	},
 	"ci": {
 		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-typography"

--- a/src/js/typography.js
+++ b/src/js/typography.js
@@ -29,12 +29,12 @@ class Typography {
 			{
 				family: 'MetricWeb',
 				weight: 600,
-				label: 'sansBold'
+				label: 'sans-bold'
 			},
 			{
 				family: 'FinancierDisplayWeb',
 				weight: 700,
-				label: 'displayBold'
+				label: 'display-bold'
 			}
 		];
 		if (this.opts.loadOnInit) {

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -34,10 +34,6 @@ $o-typography-display: '' !default;
 /// @access public
 /// @example scss
 ///    @include oTypographyCustomize((
-///        'bold-level': 'bold',
-///        'sans': (
-///            'bold-level': 'semibold'
-///        ),
 ///        'heading-level-one': (
 ///            'scale': 7,
 ///        ),
@@ -100,10 +96,6 @@ $o-typography-display: '' !default;
             'author-color': oColorsGetColorFor('body', 'text'),
             'author-hover-color': oColorsGetPaletteColor('claret'),
             'custom-link-focus-outline-color': oColorsGetPaletteColor('black-50'), //deprecated
-            'bold-level': 'bold',
-            'sans': (
-                'bold-level': 'semibold' // override the default "bold" font weight for the sans font
-            ),
             'heading-level-one': (
                 'scale': 5,
                 'weight': 'semibold'
@@ -144,7 +136,6 @@ $o-typography-display: '' !default;
     @include oBrandDefine('o-typography', 'internal', (
         'variables': (
             'custom-link-focus-outline-color': oColorsGetPaletteColor('oxford-80'), //deprecated
-            'bold-level': 'semibold',
             'heading-level-one': (
                 'scale': 5,
                 'weight': 'semibold'
@@ -211,7 +202,6 @@ $o-typography-display: '' !default;
 
     @include oBrandDefine('o-typography', 'whitelabel', (
         'variables': (
-            'bold-level': 'bold',
             'heading-level-one': (
                 'scale': 6,
             ),

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -80,18 +80,6 @@
 	}
 }
 
-/// Get the configured font weight to display a font type "bold".
-/// Returns a weight e.g. bold or semibold.
-///
-/// @access private
-/// @param {Bool | String} $font-type - the font type to style bold (i.e. 'sans', 'serif').
-/// @return {Null | Bool | String} - The font weight to style the font type bold e.g. bold or semibold. `false` or `null` is also accepted but deprecated.
-@function _oTypographyGetBoldWeight($font-type) {
-	$font-weight: _oTypographyGet('bold-level', $from: $font-type);
-	$default-bold-level: _oTypographyGet('bold-level');
-	@return if($font-weight, $font-weight, $default-bold-level);
-}
-
 /// Changes a px value to a rem value if relative units are enabled.
 /// Useful for user input such as custom line-heights, where a px value
 /// should become a rem value but otherwise the value should remain unchanged.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -29,20 +29,6 @@
 	}
 }
 
-/// Outputs font-weight property for the given font type.
-///
-/// @example Make a sans copy bold without outputting the font family again.
-///     .example-text {
-///     	@include oTypographySans($scale: 2);
-///     }
-///     .example-text--bold {
-///     	@include oTypographyBold('sans');
-///     }
-/// @param {Bool | Null | String} $font [null] - the font type to style bold (i.e. 'sans', 'serif'). `false` or `null` is also accepted but deprecated.
-@mixin oTypographyBold($font: null) {
-	font-weight: oFontsWeight(_oTypographyGetBoldWeight($font-type: $font));
-}
-
 /// Set a custom font.
 ///
 /// @example This example shows setting a custom font "MySansFont" as the "sans" font.

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -1,108 +1,141 @@
-/// Outputs font-family, size and line-height, and progressive
-/// font loading styles for Serif font
+/// Outputs typography styles for the Serif font.
+/// Including: family, size, line-height, weight, style, and font sizes
+/// for progressive font loading.
 ///
-/// @param {Bool | Number} $scale [false] - number of the scale to use
-/// @param {Bool | Number} $line-height [false] - line-height value to use instead of scale default
-/// @param {Bool} $progressive [true] - whether to output progressive font loading styles
-@mixin oTypographySerif($scale: false, $line-height: false, $progressive: true) {
+/// @example Output a font-family property only for the serif font.
+/// 	@include oTypographySerif();
+///
+/// @example Output font-family, font-size, and line-height for the serif font.
+/// 	@include oTypographySerif($scale: 1);
+///
+/// @example Output font-family, font-size, and line-height for the serif font. Set a custom line-height of 1.6.
+/// 	@include oTypographySerif($scale: 1, $line-height: 1.6);
+///
+/// @example Output font-family, font-size, line-height, and font-weight for the serif font.
+/// 	@include oTypographySerif($scale: 1, $weight: 'bold');
+///
+/// @example Output font-family, font-size, line-height, and font-style for the serif font.
+/// 	@include oTypographySerif($scale: 1, $style: 'italic');
+///
+/// @example Output serif font properties without font-family.
+/// 	@include oTypographySerif($scale: 1, $style: 'italic', $opts: ('font-family': false));
+///
+/// @example Output serif font properties without sizes for the fallback font (without progressive font loading).
+/// 	@include oTypographySerif($scale: 1, $style: 'italic', $opts: ('progressive': false));
+///
+/// @param {Null | Number} $scale [null] - a scale number to output a font-size and line-height property
+/// @param {Null | Number} $line-height [null] - custom line-height value to use instead of the scale's default
+/// @param {Null | String} $weight [null] - output a font-weight property, e.g. 'bold', 'semibold'
+/// @param {Null | String} $style [null] - output a font-style property, e.g. 'italic'
+/// @param {Map} $opts [('font-family': true, 'progressive': true)] - a map of further options. Set a key `font-family` to false to not output a font-family property. Set a key `progressive` to false to not include alternative font sizes for progressive font loading.
+@mixin oTypographySerif($scale: null, $line-height: null, $weight: null, $style: null, $opts: (
+	'font-family': true,
+	'progressive': true,
+)) {
+	$font-family: if(map-has-key($opts, 'font-family'), map-get($opts, 'font-family'), true);
+	$progressive: if(map-has-key($opts, 'progressive'), map-get($opts, 'progressive'), true);
+
 	@include _oTypographyFor($o-typography-serif, $opts: (
-		'family': true,
+		'family': $font-family,
 		'scale': $scale,
+		'style': $style,
+		'weight': $weight,
 		'custom-line-height': $line-height,
 		'progressive': $progressive
 	));
 }
 
-/// Outputs font-family, size and line-height, and progressive
-/// font loading styles for Display font
+/// Outputs typography styles for the Display font.
+/// Including: family, size, line-height, weight, style, and font sizes
+/// for progressive font loading.
 ///
-/// @param {Bool | Number} $scale [false] - number of the scale to use
-/// @param {Bool | Number} $line-height [false] - line-height value to use instead of scale default
-/// @param {Bool} $progressive [true] - whether to output progressive font loading styles
-@mixin oTypographyDisplay($scale: false, $line-height: false, $progressive: true) {
+/// @example Output a font-family property only for the display font.
+/// 	@include oTypographyDisplay();
+///
+/// @example Output font-family, font-size, and line-height for the display font.
+/// 	@include oTypographyDisplay($scale: 1);
+///
+/// @example Output font-family, font-size, and line-height for the display font. Set a custom line-height of 1.6.
+/// 	@include oTypographyDisplay($scale: 1, $line-height: 1.6);
+///
+/// @example Output font-family, font-size, line-height, and font-weight for the display font.
+/// 	@include oTypographyDisplay($scale: 1, $weight: 'bold');
+///
+/// @example Output font-family, font-size, line-height, and font-style for the display font.
+/// 	@include oTypographyDisplay($scale: 1, $style: 'italic');
+///
+/// @example Output display font properties without font-family.
+/// 	@include oTypographyDisplay($scale: 1, $style: 'italic', $opts: ('font-family': false));
+///
+/// @example Output display font properties without sizes for the fallback font (without progressive font loading).
+/// 	@include oTypographyDisplay($scale: 1, $style: 'italic', $opts: ('progressive': false));
+///
+/// @param {Null | Number} $scale [null] - a scale number to output a font-size and line-height property
+/// @param {Null | Number} $line-height [null] - custom line-height value to use instead of the scale's default
+/// @param {Null | String} $weight [null] - output a font-weight property, e.g. 'bold', 'semibold'
+/// @param {Null | String} $style [null] - output a font-style property, e.g. 'italic'
+/// @param {Map} $opts [('font-family': true, 'progressive': true)] - a map of further options. Set a key `font-family` to false to not output a font-family property. Set a key `progressive` to false to not include alternative font sizes for progressive font loading.
+@mixin oTypographyDisplay($scale: null, $line-height: null, $weight: null, $style: null, $opts: (
+	'font-family': true,
+	'progressive': true,
+)) {
+	$font-family: if(map-has-key($opts, 'font-family'), map-get($opts, 'font-family'), true);
+	$progressive: if(map-has-key($opts, 'progressive'), map-get($opts, 'progressive'), true);
+
 	@include _oTypographyFor($o-typography-display, $opts: (
-		'family': true,
+		'family': $font-family,
 		'scale': $scale,
+		'style': $style,
+		'weight': $weight,
 		'custom-line-height': $line-height,
 		'progressive': $progressive
 	));
 }
 
-/// Outputs font-family, size and line-height, and progressive
-/// font loading styles for Sans font
+/// Outputs typography styles for the Sans font.
+/// Including: family, size, line-height, weight, style, and font sizes
+/// for progressive font loading.
 ///
-/// @param {Bool | Number} $scale [false] - number of the scale to use
-/// @param {Bool | Number} $line-height [false] - line-height value to use instead of scale default
-/// @param {Bool} $progressive [true] - whether to output progressive font loading styles
-@mixin oTypographySans($scale: false, $line-height: false, $progressive: true) {
+///
+/// @example Output a font-family property only for the sans font.
+/// 	@include oTypographySans();
+///
+/// @example Output font-family, font-size, and line-height for the sans font.
+/// 	@include oTypographySans($scale: 1);
+///
+/// @example Output font-family, font-size, and line-height for the sans font. Set a custom line-height of 1.6.
+/// 	@include oTypographySans($scale: 1, $line-height: 1.6);
+///
+/// @example Output font-family, font-size, line-height, and font-weight for the sans font.
+/// 	@include oTypographySans($scale: 1, $weight: 'bold');
+///
+/// @example Output font-family, font-size, line-height, and font-style for the sans font.
+/// 	@include oTypographySans($scale: 1, $style: 'italic');
+///
+/// @example Output sans font properties without font-family.
+/// 	@include oTypographySans($scale: 1, $style: 'italic', $opts: ('font-family': false));
+///
+/// @example Output sans font properties without sizes for the fallback font (without progressive font loading).
+/// 	@include oTypographySans($scale: 1, $style: 'italic', $opts: ('progressive': false));
+///
+/// @param {Null | Number} $scale [null] - a scale number to output a font-size and line-height property
+/// @param {Null | Number} $line-height [null] - custom line-height value to use instead of the scale's default
+/// @param {Null | String} $weight [null] - output a font-weight property, e.g. 'bold', 'semibold'
+/// @param {Null | String} $style [null] - output a font-style property, e.g. 'italic'
+/// @param {Map} $opts [('font-family': true, 'progressive': true)] - a map of further options. Set a key `font-family` to false to not output a font-family property. Set a key `progressive` to false to not include alternative font sizes for progressive font loading.
+@mixin oTypographySans($scale: null, $line-height: null, $weight: null, $style: null, $opts: (
+	'font-family': true,
+	'progressive': true,
+)) {
+	$font-family: if(map-has-key($opts, 'font-family'), map-get($opts, 'font-family'), true);
+	$progressive: if(map-has-key($opts, 'progressive'), map-get($opts, 'progressive'), true);
+
 	@include _oTypographyFor($o-typography-sans, $opts: (
-		'family': true,
+		'family': $font-family,
 		'scale': $scale,
+		'style': $style,
+		'weight': $weight,
 		'custom-line-height': $line-height,
-		'progressive': $progressive
-	));
-}
-
-/// Outputs font-family, bold font-weight, size and line-height, and progressive
-/// font loading styles for Display font
-///
-/// @param {Bool | Number} $scale [false] - number of the scale to use
-/// @param {Bool | Number} $line-height [false] - line-height value to use instead of scale default
-/// @param {Bool} $progressive [true] - whether to output progressive font loading styles
-@mixin oTypographyDisplayBold($scale: false, $line-height: false, $progressive: true) {
-	@include _oTypographyFor($o-typography-display, $opts: (
-		'family': true,
-		'scale': $scale,
-		'custom-line-height': $line-height,
-		'weight': _oTypographyGetBoldWeight('display'),
-		'progressive': $progressive
-	));
-}
-
-/// Outputs font-family, bold font-weight, size and line-height, and progressive
-/// font loading styles for Sans font
-///
-/// @param {Bool | Number} $scale [false] - number of the scale to use
-/// @param {Bool | Number} $line-height [false] - line-height value to use instead of scale default
-/// @param {Bool} $progressive [true] - whether to output progressive font loading styles
-@mixin oTypographySansBold($scale: false, $line-height: false, $progressive: true) {
-	@include _oTypographyFor($o-typography-sans, $opts: (
-		'family': true,
-		'scale': $scale,
-		'custom-line-height': $line-height,
-		'weight': _oTypographyGetBoldWeight('sans'),
-		'progressive': $progressive
-	));
-}
-
-/// Outputs font-family, bold font-weight, size and line-height, and progressive
-/// font loading styles for Serif font
-///
-/// @param {Bool | Number} $scale [false] - number of the scale to use
-/// @param {Bool | Number} $line-height [false] - line-height value to use instead of scale default
-/// @param {Bool} $progressive [true] - whether to output progressive font loading styles
-@mixin oTypographySerifBold($scale: false, $line-height: false, $progressive: true) {
-	@include _oTypographyFor($o-typography-serif, $opts: (
-		'family': true,
-		'scale': $scale,
-		'custom-line-height': $line-height,
-		'weight': _oTypographyGetBoldWeight('serif'),
-		'progressive': $progressive
-	));
-}
-
-/// Outputs font-family, italic font-style, size and line-height, and progressive
-/// font loading styles for Serif font
-///
-/// @param {Bool | Number} $scale [false] - number of the scale to use
-/// @param {Bool | Number} $line-height [false] - line-height value to use instead of scale default
-/// @param {Bool} $progressive [true] - whether to output progressive font loading styles
-@mixin oTypographySerifItalic($scale: false, $line-height: false, $progressive: true) {
-	@include _oTypographyFor($o-typography-serif, $opts: (
-		'family': true,
-		'scale': $scale,
-		'custom-line-height': $line-height,
-		'style': 'italic',
 		'progressive': $progressive
 	));
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -66,7 +66,7 @@ $_o-typography-progressive-font-fallbacks: (
 		fallback-scale: 0.87
 	),
 	(
-		label: 'sansBold',
+		label: 'sans-bold',
 		family: 'MetricWeb',
 		weight: ('bold', 'semibold'),
 		fallback: sans-serif,
@@ -79,7 +79,7 @@ $_o-typography-progressive-font-fallbacks: (
 		fallback-scale: 0.9
 	),
 	(
-		label: 'displayBold',
+		label: 'display-bold',
 		family: 'FinancierDisplayWeb',
 		weight: bold,
 		fallback: serif,

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -134,11 +134,6 @@
 	}
 }
 
-/// Make something italic
-@mixin oTypographyItalic {
-	font-style: italic;
-}
-
 /// Styling for <ul> and <ol>
 @mixin oTypographyList {
 	margin-top: 0;
@@ -175,7 +170,10 @@
 
 
 			&:before {
-				@include oTypographySansBold($scale: 0);
+				@include oTypographySans (
+					$scale: 0,
+					$weight: 'semibold'
+				);
 				position: absolute;
 				display: inline-block;
 				width: oSpacingByIncrement(5);

--- a/src/scss/use-cases/_wrapper.scss
+++ b/src/scss/use-cases/_wrapper.scss
@@ -56,11 +56,14 @@
 	}
 
 	> strong {
-		@include oTypographyBold;
+		@include oTypographySans (
+			$weight: 'semibold',
+			$opts: ('font-family': false)
+		);
 	}
 
 	> em {
-		@include oTypographyItalic;
+		font-style: italic;
 	}
 
 	> sup {

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,3 +1,314 @@
+@include test-module('oTypographySans') {
+    @include test('Outputs a font family.') {
+        @include assert {
+            @include output {
+                @include oTypographySans();
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, and progressive loading sizes for a given scale.') {
+        @include assert {
+            @include output {
+                @include oTypographySans(1);
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
+                font-size: 18px;
+                line-height: 20px;
+                .o-typography--loading-sans & {
+                    font-size: 15.66px;
+                    font-family: sans-serif;
+                }
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, and progressive loading sizes for a given scale and custom line height.') {
+        @include assert {
+            @include output {
+                @include oTypographySans(1, 1.6);
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
+                font-size: 18px;
+                line-height: 1.6;
+                .o-typography--loading-sans & {
+                    font-size: 15.66px;
+                    font-family: sans-serif;
+                }
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, weight, and progressive loading sizes for a given scale and weight.') {
+        @include assert {
+            @include output {
+                @include oTypographySans(1, $weight: 'bold');
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
+                font-size: 18px;
+                line-height: 20px;
+                font-weight: 700;
+                .o-typography--loading-sansBold & {
+                    font-size: 14.94px;
+                    font-family: sans-serif;
+                }
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, style, and progressive loading sizes for a given scale and style.') {
+        @include assert {
+            @include output {
+                @include oTypographySans(1, $style: 'italic');
+            }
+
+            // there are no progressive loading scale defined for an italic sans font
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
+                font-size: 18px;
+                line-height: 20px;
+                font-style: italic;
+            }
+        }
+    }
+
+    @include test('Does not output a font-family when the option is set to false') {
+        @include assert {
+            @include output {
+                @include oTypographySans(1, 1.6, $opts: (
+                    'font-family': false
+                ));
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 1.6;
+
+                .o-typography--loading-sans & {
+                    font-size: 15.66px;
+                    font-family: sans-serif;
+                }
+            }
+        }
+    }
+
+    @include test('Does not output a progressive font fallback scale when the `progressive` option is set to false') {
+        @include assert {
+            @include output {
+                @include oTypographySans(1, 1.6, $opts: (
+                    'progressive': false
+                ));
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
+                font-size: 18px;
+                line-height: 1.6;
+            }
+        }
+    }
+}
+
+@include test-module('oTypographySerif') {
+    @include test('Outputs a font family.') {
+        @include assert {
+            @include output {
+                @include oTypographySerif();
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(Georgia);
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, and line height for a given scale.') {
+        @include assert {
+            @include output {
+                @include oTypographySerif(1);
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(Georgia);
+                font-size: 18px;
+                line-height: 20px;
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, and line height for a given scale and custom line height.') {
+        @include assert {
+            @include output {
+                @include oTypographySerif(1, 1.6);
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(Georgia);
+                font-size: 18px;
+                line-height: 1.6;
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, and weight for a given scale and weight.') {
+        @include assert {
+            @include output {
+                @include oTypographySerif(1, $weight: 'bold');
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(Georgia);
+                font-size: 18px;
+                line-height: 20px;
+                font-weight: 700;
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, style, for a given scale and style.') {
+        @include assert {
+            @include output {
+                @include oTypographySerif(1, $style: 'italic');
+            }
+
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(Georgia);
+                font-size: 18px;
+                line-height: 20px;
+                font-style: italic;
+            }
+        }
+    }
+
+    @include test('Does not output a font-family when the option is set to false') {
+        @include assert {
+            @include output {
+                @include oTypographySerif(1, 1.6, $opts: (
+                    'font-family': false
+                ));
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 1.6;
+            }
+        }
+    }
+
+    @include test('Does not output a progressive font fallback scale when the `progressive` option is set to false') {
+        @include assert {
+            @include output {
+                @include oTypographySerif(1, 1.6, $opts: (
+                    'progressive': false
+                ));
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(Georgia);
+                font-size: 18px;
+                line-height: 1.6;
+            }
+        }
+    }
+}
+
+@include test-module('oTypographyDisplay') {
+    @include test('Outputs a font family.') {
+        @include assert {
+            @include output {
+                @include oTypographyDisplay();
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, and progressive loading sizes for a given scale.') {
+        @include assert {
+            @include output {
+                @include oTypographyDisplay(1);
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
+                font-size: 18px;
+                line-height: 20px;
+                .o-typography--loading-display & {
+                    font-size: 16.2px;
+                    font-family: serif;
+                }
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, and progressive loading sizes for a given scale and custom line height.') {
+        @include assert {
+            @include output {
+                @include oTypographyDisplay(1, 1.6);
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
+                font-size: 18px;
+                line-height: 1.6;
+                .o-typography--loading-display & {
+                    font-size: 16.2px;
+                    font-family: serif;
+                }
+            }
+        }
+    }
+
+    @include test('Outputs a font family, size, line height, weight, and progressive loading sizes for a given scale and weight.') {
+        @include assert {
+            @include output {
+                @include oTypographyDisplay(1, $weight: 'bold');
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
+                font-size: 18px;
+                line-height: 20px;
+                font-weight: 700;
+                .o-typography--loading-displayBold & {
+                    font-size: 16.2px;
+                    font-family: serif;
+                }
+            }
+        }
+    }
+
+    @include test('Does not output a font-family when the option is set to false') {
+        @include assert {
+            @include output {
+                @include oTypographyDisplay(1, 1.6, $opts: (
+                    'font-family': false
+                ));
+            }
+            @include expect {
+                font-size: 18px;
+                line-height: 1.6;
+
+                .o-typography--loading-display & {
+                    font-size: 16.2px;
+                    font-family: serif;
+                }
+            }
+        }
+    }
+
+    @include test('Does not output a progressive font fallback scale when the `progressive` option is set to false') {
+        @include assert {
+            @include output {
+                @include oTypographyDisplay(1, 1.6, $opts: (
+                    'progressive': false
+                ));
+            }
+            @include expect {
+                font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
+                font-size: 18px;
+                line-height: 1.6;
+            }
+        }
+    }
+}
+
 @include test-module('oTypographyDefineFontScale') {
     $custom-font-scale: (
         -2: (1, 1),
@@ -218,88 +529,6 @@
                 &::after {
                     background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:outside-page?source=o-icons&tint=%23FF0000,%23FF0000&format=svg");
                 }
-            }
-        }
-    }
-}
-
-@include test-module('oTypographyBold') {
-    @include test('Outputs the default font weight if not given a font type (the FinancierDisplayWeb bold weight for the master brand).') {
-        @include assert {
-            @include output {
-                @include oTypographyBold();
-            }
-            @include contains {
-                font-weight: 700;
-            }
-        }
-    }
-    @include test('Outputs the sans "bold" font weight of 600 (semibold).') {
-        @include assert {
-            @include output {
-                @include oTypographyBold('sans');
-            }
-            @include contains {
-                font-weight: 600;
-            }
-        }
-    }
-    @include test('Outputs the serif "bold" font weight.') {
-        @include assert {
-            @include output {
-                @include oTypographyBold('serif');
-            }
-            @include contains {
-                font-weight: 700;
-            }
-        }
-    }
-    @include test('Outputs the display "bold" font weight.') {
-        @include assert {
-            @include output {
-                @include oTypographyBold('display');
-            }
-            @include contains {
-                font-weight: 700;
-            }
-        }
-    }
-}
-
-@include test-module('oTypographySansBold') {
-    @include test('Outputs the sans "bold" font weight of 600 (semibold).') {
-        @include assert {
-            @include output {
-                @include oTypographySansBold($scale: 1);
-            }
-            @include contains {
-                font-weight: 600;
-            }
-        }
-    }
-}
-
-@include test-module('oTypographySerifBold') {
-    @include test('Outputs the serif "bold" font weight of 700 (bold).') {
-        @include assert {
-            @include output {
-                @include oTypographySerifBold($scale: 1);
-            }
-            @include contains {
-                font-weight: 700;
-            }
-        }
-    }
-}
-
-@include test-module('oTypographyDisplayBold') {
-    @include test('Outputs the display "bold" font weight of 700 (bold).') {
-        @include assert {
-            @include output {
-                @include oTypographyDisplayBold($scale: 1);
-            }
-            @include contains {
-                font-weight: 700;
             }
         }
     }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -54,7 +54,7 @@
                 font-size: 18px;
                 line-height: 20px;
                 font-weight: 700;
-                .o-typography--loading-sansBold & {
+                .o-typography--loading-sans-bold & {
                     font-size: 14.94px;
                     font-family: sans-serif;
                 }
@@ -266,7 +266,7 @@
                 font-size: 18px;
                 line-height: 20px;
                 font-weight: 700;
-                .o-typography--loading-displayBold & {
+                .o-typography--loading-display-bold & {
                     font-size: 16.2px;
                     font-family: serif;
                 }

--- a/test/typography.test.js
+++ b/test/typography.test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon/pkg/sinon';
 
 import Typography from './../main';
 
-const fontLabels = ['display', 'sans', 'sansBold', 'displayBold'];
+const fontLabels = ['display', 'sans', 'sans-bold', 'display-bold'];
 const stubPrefix = 'loading-font-';
 const stubCookieName = 'fonts-loaded';
 


### PR DESCRIPTION
Removes the following mixins in favour of updating the arguments of related
mixins [see the v6 proposal](https://github.com/Financial-Times/o-typography/issues/203):
- oTypographySansBold
- oTypographyDisplayBold
- oTypographySerifBold
- oTypographySerifItalic
- oTypographyBold
- oTypographyItalic

Instead `oTypographySans`, `oTypographyDisplay`, and `oTypographySerif` accept a
`$weight` and `$style` argument. If the given weight or style does not have
a corresponding font in Origami an error is thrown. The `$progressive` parameter
has been moved within an `$opts` map to optionally exclude the sizes of a
fallback font, and in addition a font-family option has been added to exclude
the font family; so these mixins may be used to modify a font size without
repeating the font-family declaration. See the tests and SassDoc examples.

README.md is out of date and MIGRATION.md has only a list of changes.
They will be updated with in a later commit.

Update:
The class `o-typography--loading-sansBold` is now `o-typography--loading-sans-bold` and `o-typography--loading-displayBold` is now `o-typography--loading-display-bold`.