### PR TITLE
Update subscript and superscript size and positioning.

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -27,18 +27,32 @@
 
 /// Subscript text
 @mixin oTypographySub {
-	@include oTypographySans(-2);
-	display: inline-block;
-	margin-bottom: _oTypographyAdjustUnit(-5px);
+	// make subscript smaller and sans-serif
+	// 12px given 18px copy
+	@include oTypographySans();
+	font-size: 0.666em;
+	// override o-normalise default
+	position: static;
 	vertical-align: sub;
+	line-height: 0;
+	// prevent sub increasing line-height
+	display: inline-block;
+	margin-bottom: -1em;
 }
 
 /// Superscript text
 @mixin oTypographySuper {
-	@include oTypographySans(-2);
-	display: inline-block;
-	margin-top: _oTypographyAdjustUnit(-3px);
+	// make superscript smaller and sans-serif
+	// 12px given 18px copy
+	@include oTypographySans();
+	font-size: 0.666em;
+	// override o-normalise default
+	position: static;
 	vertical-align: super;
+	line-height: 0;
+	// prevent super increasing line-height
+	display: inline-block;
+	margin-top: -1em;
 }
 
 /// Output link styles.


### PR DESCRIPTION
o-normalise applies styles to sub and sup tags. These interact with
seperate styles applied by o-typography. This appears to have caused
unusually high/low superscript/subscript elements (confirmed with
the design team).

before
<img width="1296" alt="Screenshot 2019-10-23 at 13 40 33" src="https://user-images.githubusercontent.com/10405691/67394171-a9dbc880-f59b-11e9-8493-7f738772bbeb.png">

after
<img width="1296" alt="Screenshot 2019-10-23 at 13 40 34" src="https://user-images.githubusercontent.com/10405691/67394182-af391300-f59b-11e9-8e42-37cc979db7af.png">

This commit corrects the position by overriding default o-normalise
styles. It also sets the size of superscript/subscript elements
using relative units so they work in contexts outside of body copy.