### PR TITLE
Update `oTypographyMaxLineWidth` to use relative units.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,6 +18,8 @@ The following mixins have been replaced:
 - oTypographyLinkExternal: oTypographyLink($external: true);
 - oTypographyLinkExternalIcon: oTypographyLink($external: true, $include-base-styles: false);
 
+The following mixins have been updated:
+- oTypographyMaxLineWidth: Returns a relative `ch` rather than `px` value. The `$scale` and `$font` parameters are redundant and have been removed.
 The following mixins have been removed:
 - oTypographyProgressiveFontFallback: progressive font fallbacks are output by other mixins
 

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -2,13 +2,14 @@
 import './../../main.js';
 
 function setWidths () {
-	let selection = document.querySelector('.select-scale');
+	let selection = document.querySelector('#select-scale');
 
 	if (selection) {
 		let text = document.querySelector('p');
 		selection.addEventListener('change', () => {
 			text.classList = '';
-			text.classList.add(`scale-${selection.value}`);
+			text.classList.add('line-width-demo__scale');
+			text.classList.add(`line-width-demo__scale--${selection.value}`);
 		});
 	}
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -46,15 +46,18 @@ html {
 .line-width-demo {
 	display: flex;
 
-	.selection {
+	.line-width-demo__selection {
 		min-width: 100px;
 		margin: 20px;
 	}
 
+	.line-width-demo__scale {
+		max-width: oTypographyMaxLineWidth();
+	}
+
 	@each $scale, $values in $o-typography-font-scale {
-		.scale-#{$scale} {
+		.line-width-demo__scale--#{$scale} {
 			@include oTypographySans($scale);
-			max-width: oTypographyMaxLineWidth($scale);
 		}
 	}
 }

--- a/demos/src/line-width.mustache
+++ b/demos/src/line-width.mustache
@@ -1,6 +1,6 @@
 <div class="line-width-demo">
-	<div class="selection">
-		Scale: <select class="select-scale">
+	<div class="line-width-demo__ selection">
+		Scale: <select id="select-scale">
 			<option value="-2">-2</option>
 			<option value="-1">-1</option>
 			<option value="0" selected>0</option>
@@ -17,7 +17,7 @@
 		</select>
 	</div>
 
-	<p class="scale-0">
+	<p class="line-width-demo__scale line-width-demo__scale--0">
 		dictum, ultrices eros non, varius enim. Aenean quis porttitor magna, quis rutrum eros. Proin elementum justo a massa suscipit iaculis vel eget ex. Mauris non est non quam vestibulum scelerisque in a purus. Donec varius augue at est vulputate convallis. Proin accumsan varius nulla, nec sagittis tortor aliquet vitae. Praesent nunc diam, cursus vitae tellus ac, lobortis posuere quam. Mauris nibh arcu, aliquam quis ultricies non, ultrices in sapien. Quisque placerat ipsum a metus consectetur, vel sagittis velit sodales.
 		Morbi a nulla in mi tincidunt ultricies. Morbi mollis maximus est. Sed non elit bibendum, auctor orci lacinia, interdum augue. Sed pharetra id urna vel luctus. Phasellus elementum pulvinar leo et porta. Proin blandit id diam at ullamcorper. Nunc id blandit justo. Nam et vestibulum sem.
 	</p>

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -17,8 +17,8 @@
 	// a ch unit represents the width of the glyph "0"
 	// it's a wide glyph so we'll reduce the ch value by an arbitrary amount
 	// to bring our characters per line closer to the requested number on average
-	$magin-number: 0.75;
-	@return $optimal-characters-per-line * $magin-number * 1ch;
+	$magic-number: 0.75;
+	@return $optimal-characters-per-line * $magic-number * 1ch;
 }
 
 /// Returns the font-size value from the scale passed in

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -9,6 +9,18 @@
 	@return map-get($scale, $index);
 }
 
+/// Returns a maximum line width based on the given scale
+///
+/// @param {Number} $optimal-characters-per-line - number of the characters per line
+/// @returns {String} maximum line width in ch
+@function oTypographyMaxLineWidth($optimal-characters-per-line: 65) {
+	// a ch unit represents the width of the glyph "0"
+	// it's a wide glyph so we'll reduce the ch value by an arbitrary amount
+	// to bring our characters per line closer to the requested number on average
+	$magin-number: 0.75;
+	@return $optimal-characters-per-line * $magin-number * 1ch;
+}
+
 /// Returns the font-size value from the scale passed in
 /// modified by the font-adjust if present
 ///
@@ -37,24 +49,6 @@
 		$line-height: nth($settings, 2);
 		@return if($line-height, _oTypographyAddUnit($line-height), null);
 	}
-}
-
-/// Returns a maximum line width based on the given scale
-///
-/// @param {Number} $scale - number of the scale to return
-/// @param {Number} $optimal-characters-per-line - number of the characters per line
-/// @param {String} $font [''] - The font to get the max line width for, as fonts may have different scales. Uses the default scale if not specified.
-/// @returns {Number} maximum line width in px
-@function oTypographyMaxLineWidth($scale: 0, $optimal-characters-per-line: 65, $font: '') {
-	$settings: oTypographyGetScale($scale, $font);
-
-	$font-size: _oTypographyAddUnit(nth($settings, 1));
-	$line-height: if(nth($settings, 2), _oTypographyAddUnit(nth($settings, 2)), $font-size);
-
-	$golden-ratio: 1.618;
-	$scale-ratio: ($font-size / $line-height)  + $golden-ratio; //adapts ratio to quirks in oTypography's line-heights
-
-	@return $optimal-characters-per-line * ($font-size / $scale-ratio);
 }
 
 /// Get font family for family style i.e "sans", "serif", or "display".


### PR DESCRIPTION
`oTypographyMaxLineWidth` now returns a relative `ch` rather than
`px` value. The `$scale` and `$font` parameters are redundant and
have been removed.