### PR TITLE
Remove oTypographySize.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,6 +18,8 @@ The following mixins have been replaced:
 - oTypographyLinkExternal: oTypographyLink($external: true);
 - oTypographyLinkExternalIcon: oTypographyLink($external: true, $include-base-styles: false);
 - oTypographySize: oTypographySans($scale: 1, $opts: ('font-family': false))
+- oTypographyListOrdered: oTypographyList($type: 'ordered', $include-base-styles: false)
+- oTypographyListUnordered: oTypographyList($type: 'unordered', $include-base-styles: false)
 
 The following mixins have been updated:
 - oTypographyMaxLineWidth: Returns a relative `ch` rather than `px` value. The `$scale` and `$font` parameters are redundant and have been removed.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,6 +17,7 @@ The following mixins have been replaced:
 - oTypographyLinkCustom: oTypographyLink($theme: ('base': 'claret', 'hover': 'claret-30'));
 - oTypographyLinkExternal: oTypographyLink($external: true);
 - oTypographyLinkExternalIcon: oTypographyLink($external: true, $include-base-styles: false);
+- oTypographySize: oTypographySans($scale: 1, $opts: ('font-family': false))
 
 The following mixins have been updated:
 - oTypographyMaxLineWidth: Returns a relative `ch` rather than `px` value. The `$scale` and `$font` parameters are redundant and have been removed.

--- a/main.scss
+++ b/main.scss
@@ -114,15 +114,18 @@
 
 	@if $lists-enabled {
 		.o-typography-list {
-			@include oTypographyList;
+			// Output base styles shared by all list types.
+			@include oTypographyList();
 		}
 
 		.o-typography-list--ordered {
-			@include oTypographyListOrdered;
+			// Output list styles unique to an ordered list.
+			@include oTypographyList($type: 'ordered', $include-base-styles: false);
 		}
 
 		.o-typography-list--unordered {
-			@include oTypographyListUnordered;
+			// Output list styles unique to an unordered list.
+			@include oTypographyList($type: 'unordered', $include-base-styles: false);
 		}
 	}
 

--- a/main.scss
+++ b/main.scss
@@ -70,7 +70,7 @@
 		.o-typography-bold {
 			@include oTypographySans (
 				$weight: 'semibold',
-				$opts: ('font-family': false)
+				$include-font-family: false
 			);
 		}
 

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -51,9 +51,6 @@ $o-typography-display: '' !default;
 ///        ),
 ///        'heading-level-six': (
 ///            'scale': 2
-///        ),
-///        'body': (
-///            'bottom-spacing-size': 8,
 ///        )
 ///    ));
 @mixin oTypographyCustomize($variables) {
@@ -64,8 +61,7 @@ $o-typography-display: '' !default;
         'heading-level-three',
         'heading-level-four',
         'heading-level-five',
-        'heading-level-six',
-        'body',
+        'heading-level-six'
     );
     @each $brand-variable in map-keys($variables) {
         @if not index($allowed-brand-variables, $brand-variable) {
@@ -116,11 +112,6 @@ $o-typography-display: '' !default;
             'heading-level-six': (
                 'scale': 2,
                 'weight': 'semibold'
-            ),
-            'body': (
-                'font-type': 'serif',
-                'bottom-spacing-size': 7,
-                'custom-line-height': 28px,
             )
         ),
         'supports-variants': ()
@@ -155,9 +146,6 @@ $o-typography-display: '' !default;
             'heading-level-six': (
                 'scale': 2,
                 'weight': 'semibold'
-            ),
-            'body': (
-                'bottom-spacing-size': 7,
             )
         ),
         'supports-variants': ()
@@ -217,9 +205,6 @@ $o-typography-display: '' !default;
             ),
             'heading-level-six': (
                 'scale': 1
-            ),
-            'body': (
-                'bottom-spacing-size': 7,
             )
         ),
         'supports-variants': ()

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -67,7 +67,8 @@
 /// @param {Number} $scale - Number on scale the size is based on.
 /// @param {String} $weight [null] - The weight of the font which needs a fallback e.g. 'bold'.
 /// @param {String} $style [null] - The style of the font which needs a fallback e.g. 'italic'.
-@mixin _oTypographyProgressiveFontFallback($font, $scale, $weight: null, $style: null) {
+/// @param {Boolean} $include-font-family [true] - Whether to output the font family of the fallback font (vs. just the size)
+@mixin _oTypographyProgressiveFontFallback($font, $scale, $weight: null, $style: null, $include-font-family: true) {
 	@if $scale {
 		// If falsy weight/style default to regular/normal.
 		$weight: if($weight, $weight, 'regular');
@@ -93,7 +94,9 @@
 			@if ($label-match or ($family-match and $weight-match and $style-match)) {
 				.#{$o-typography-loading-prefix}-#{$fallback-label} & {
 					@include _oTypographyFontSize($scale: $scale, $progressive-font-adjust: $fallback-scale, $font: $fallback-family);
-					font-family: map-get($fallback, 'fallback');
+					@if $include-font-family {
+						font-family: map-get($fallback, 'fallback');
+					}
 				}
 			}
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,34 +1,3 @@
-/// Outputs the font size and line height based on the scale, also
-/// accepts an override line-height to output and a font adjustment
-/// parameter for when outputting styles for progressively loaded fonts
-///
-/// @param {Number} $scale number on scale the sizes are based on
-/// @param {Bool | Number} $line-height size to override the line-height property
-/// @param {String} $font [''] - The font to get the font size for, as fonts may have different scales. Uses the default scale if not specified.
-@mixin oTypographySize($scale, $line-height: false, $font: '') {
-	@if type-of($scale) == map {
-		@each $breakpoint, $scale in $scale {
-			$current-line-height: if(length($scale) == 2, nth($scale, 2), $line-height);
-			$current-scale: if(type-of($scale) == list and length($scale) != 0, nth($scale, 1), $scale);
-
-			@if $breakpoint == 'default' and $current-scale {
-				font-size: _oTypographyFontSizeFromScale($current-scale, 1, $font);
-				line-height: _oTypographyLineHeightFromScale($current-scale, $current-line-height, $font);
-			}
-
-			@if $breakpoint != 'default' and $current-scale {
-				@include oGridRespondTo($breakpoint) {
-					font-size: _oTypographyFontSizeFromScale($current-scale, 1, $font);
-					line-height: _oTypographyLineHeightFromScale($current-scale, $current-line-height, $font);
-				}
-			}
-		}
-	} @else {
-		font-size: _oTypographyFontSizeFromScale($scale, 1, $font);
-		line-height: _oTypographyLineHeightFromScale($scale, $line-height, $font);
-	}
-}
-
 /// Set a custom font.
 ///
 /// @example This example shows setting a custom font "MySansFont" as the "sans" font.

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -18,30 +18,32 @@
 /// 	@include oTypographySerif($scale: 1, $style: 'italic');
 ///
 /// @example Output serif font properties without font-family.
-/// 	@include oTypographySerif($scale: 1, $style: 'italic', $opts: ('font-family': false));
+/// 	@include oTypographySerif($scale: 1, $style: 'italic', $include-font-family: false);
 ///
 /// @example Output serif font properties without sizes for the fallback font (without progressive font loading).
-/// 	@include oTypographySerif($scale: 1, $style: 'italic', $opts: ('progressive': false));
+/// 	@include oTypographySerif($scale: 1, $style: 'italic', $include-progressive: false);
 ///
 /// @param {Null | Number} $scale [null] - a scale number to output a font-size and line-height property
 /// @param {Null | Number} $line-height [null] - custom line-height value to use instead of the scale's default
 /// @param {Null | String} $weight [null] - output a font-weight property, e.g. 'bold', 'semibold'
 /// @param {Null | String} $style [null] - output a font-style property, e.g. 'italic'
-/// @param {Map} $opts [('font-family': true, 'progressive': true)] - a map of further options. Set a key `font-family` to false to not output a font-family property. Set a key `progressive` to false to not include alternative font sizes for progressive font loading.
-@mixin oTypographySerif($scale: null, $line-height: null, $weight: null, $style: null, $opts: (
-	'font-family': true,
-	'progressive': true,
-)) {
-	$font-family: if(map-has-key($opts, 'font-family'), map-get($opts, 'font-family'), true);
-	$progressive: if(map-has-key($opts, 'progressive'), map-get($opts, 'progressive'), true);
-
+/// @param {Boolean} $include-font-family [true] - Set to false to exclude the font-family property from the output. This is useful when resizing typography, where the serif font-family is inherited from a parent element.
+/// @param {Boolean} $include-progressive [true] - Set to false to exclude styles used for progressive font loading (font-family and size fallbacks for loading fonts).
+@mixin oTypographySerif(
+	$scale: null,
+	$line-height: null,
+	$weight: null,
+	$style: null,
+	$include-font-family: true,
+	$include-progressive: true
+) {
 	@include _oTypographyFor($o-typography-serif, $opts: (
-		'family': $font-family,
+		'family': $include-font-family,
 		'scale': $scale,
 		'style': $style,
 		'weight': $weight,
 		'custom-line-height': $line-height,
-		'progressive': $progressive
+		'progressive': $include-progressive
 	));
 }
 
@@ -65,30 +67,32 @@
 /// 	@include oTypographyDisplay($scale: 1, $style: 'italic');
 ///
 /// @example Output display font properties without font-family.
-/// 	@include oTypographyDisplay($scale: 1, $style: 'italic', $opts: ('font-family': false));
+/// 	@include oTypographyDisplay($scale: 1, $style: 'italic', $include-font-family: false);
 ///
 /// @example Output display font properties without sizes for the fallback font (without progressive font loading).
-/// 	@include oTypographyDisplay($scale: 1, $style: 'italic', $opts: ('progressive': false));
+/// 	@include oTypographyDisplay($scale: 1, $style: 'italic', $include-progressive: false);
 ///
 /// @param {Null | Number} $scale [null] - a scale number to output a font-size and line-height property
 /// @param {Null | Number} $line-height [null] - custom line-height value to use instead of the scale's default
 /// @param {Null | String} $weight [null] - output a font-weight property, e.g. 'bold', 'semibold'
 /// @param {Null | String} $style [null] - output a font-style property, e.g. 'italic'
-/// @param {Map} $opts [('font-family': true, 'progressive': true)] - a map of further options. Set a key `font-family` to false to not output a font-family property. Set a key `progressive` to false to not include alternative font sizes for progressive font loading.
-@mixin oTypographyDisplay($scale: null, $line-height: null, $weight: null, $style: null, $opts: (
-	'font-family': true,
-	'progressive': true,
-)) {
-	$font-family: if(map-has-key($opts, 'font-family'), map-get($opts, 'font-family'), true);
-	$progressive: if(map-has-key($opts, 'progressive'), map-get($opts, 'progressive'), true);
-
+/// @param {Boolean} $include-font-family [true] - Set to false to exclude the font-family property from the output. This is useful when resizing typography, where the display font-family is inherited from a parent element.
+/// @param {Boolean} $include-progressive [true] - Set to false to exclude styles used for progressive font loading (font-family and size fallbacks for loading fonts).
+@mixin oTypographyDisplay(
+	$scale: null,
+	$line-height: null,
+	$weight: null,
+	$style: null,
+	$include-font-family: true,
+	$include-progressive: true
+) {
 	@include _oTypographyFor($o-typography-display, $opts: (
-		'family': $font-family,
+		'family': $include-font-family,
 		'scale': $scale,
 		'style': $style,
 		'weight': $weight,
 		'custom-line-height': $line-height,
-		'progressive': $progressive
+		'progressive': $include-progressive
 	));
 }
 
@@ -113,30 +117,32 @@
 /// 	@include oTypographySans($scale: 1, $style: 'italic');
 ///
 /// @example Output sans font properties without font-family.
-/// 	@include oTypographySans($scale: 1, $style: 'italic', $opts: ('font-family': false));
+/// 	@include oTypographySans($scale: 1, $style: 'italic', $include-font-family: false);
 ///
 /// @example Output sans font properties without sizes for the fallback font (without progressive font loading).
-/// 	@include oTypographySans($scale: 1, $style: 'italic', $opts: ('progressive': false));
+/// 	@include oTypographySans($scale: 1, $style: 'italic', $include-progressive: false);
 ///
 /// @param {Null | Number} $scale [null] - a scale number to output a font-size and line-height property
 /// @param {Null | Number} $line-height [null] - custom line-height value to use instead of the scale's default
 /// @param {Null | String} $weight [null] - output a font-weight property, e.g. 'bold', 'semibold'
 /// @param {Null | String} $style [null] - output a font-style property, e.g. 'italic'
-/// @param {Map} $opts [('font-family': true, 'progressive': true)] - a map of further options. Set a key `font-family` to false to not output a font-family property. Set a key `progressive` to false to not include alternative font sizes for progressive font loading.
-@mixin oTypographySans($scale: null, $line-height: null, $weight: null, $style: null, $opts: (
-	'font-family': true,
-	'progressive': true,
-)) {
-	$font-family: if(map-has-key($opts, 'font-family'), map-get($opts, 'font-family'), true);
-	$progressive: if(map-has-key($opts, 'progressive'), map-get($opts, 'progressive'), true);
-
+/// @param {Boolean} $include-font-family [true] - Set to false to exclude the font-family property from the output. This is useful when resizing typography, where the sans font-family is inherited from a parent element.
+/// @param {Boolean} $include-progressive [true] - Set to false to exclude styles used for progressive font loading (font-family and size fallbacks for loading fonts).
+@mixin oTypographySans(
+	$scale: null,
+	$line-height: null,
+	$weight: null,
+	$style: null,
+	$include-font-family: true,
+	$include-progressive: true
+) {
 	@include _oTypographyFor($o-typography-sans, $opts: (
-		'family': $font-family,
+		'family': $include-font-family,
 		'scale': $scale,
 		'style': $style,
 		'weight': $weight,
 		'custom-line-height': $line-height,
-		'progressive': $progressive
+		'progressive': $include-progressive
 	));
 }
 

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -37,14 +37,15 @@
 	$include-font-family: true,
 	$include-progressive: true
 ) {
-	@include _oTypographyFor($o-typography-serif, $opts: (
-		'family': $include-font-family,
-		'scale': $scale,
-		'style': $style,
-		'weight': $weight,
-		'custom-line-height': $line-height,
-		'progressive': $include-progressive
-	));
+	@include _oTypographyFor(
+		$o-typography-serif,
+		$scale,
+		$line-height,
+		$weight,
+		$style,
+		$include-font-family,
+		$include-progressive
+	);
 }
 
 /// Outputs typography styles for the Display font.
@@ -86,14 +87,15 @@
 	$include-font-family: true,
 	$include-progressive: true
 ) {
-	@include _oTypographyFor($o-typography-display, $opts: (
-		'family': $include-font-family,
-		'scale': $scale,
-		'style': $style,
-		'weight': $weight,
-		'custom-line-height': $line-height,
-		'progressive': $include-progressive
-	));
+	@include _oTypographyFor(
+		$o-typography-display,
+		$scale,
+		$line-height,
+		$weight,
+		$style,
+		$include-font-family,
+		$include-progressive
+	);
 }
 
 /// Outputs typography styles for the Sans font.
@@ -136,30 +138,35 @@
 	$include-font-family: true,
 	$include-progressive: true
 ) {
-	@include _oTypographyFor($o-typography-sans, $opts: (
-		'family': $include-font-family,
-		'scale': $scale,
-		'style': $style,
-		'weight': $weight,
-		'custom-line-height': $line-height,
-		'progressive': $include-progressive
-	));
+	@include _oTypographyFor(
+		$o-typography-sans,
+		$scale,
+		$line-height,
+		$weight,
+		$style,
+		$include-font-family,
+		$include-progressive
+	);
 }
 
 /// Output a typography for font
 /// @param {String} $font - The font to output typography for.
-/// @param {Map} $opts - What typography styles to output: family (boolean), scale (number -2 - 12), custom-line-height (e.g. 1em), weight (e.g. bold), style (e.g. italic), progressive (boolean).
+/// @param {Null | Number} $scale [null] - a scale number to output a font-size and line-height property
+/// @param {Null | Number} $line-height [null] - custom line-height value to use instead of the scale's default
+/// @param {Null | String} $weight [null] - output a font-weight property, e.g. 'bold', 'semibold'
+/// @param {Null | String} $style [null] - output a font-style property, e.g. 'italic'
+/// @param {Boolean} $include-font-family [true] - Set to false to exclude the font-family property from the output. This is useful when resizing typography, where the given font-family is inherited from a parent element.
+/// @param {Boolean} $include-progressive [true] - Set to false to exclude styles used for progressive font loading (font-family and size fallbacks for loading fonts).
 /// @access private
-@mixin _oTypographyFor($font, $opts: ()) {
-	// Get options, null default.
-	$include-font-family: map-get($opts, 'family');
-	$scale: map-get($opts, 'scale');
-	$custom-line-height: map-get($opts, 'custom-line-height');
-	$weight: map-get($opts, 'weight');
-	$style: map-get($opts, 'style');
-	// Get options, true default.
-	$progressive: if(map-has-key($opts, 'progressive'), map-get($opts, 'progressive'), true);
-
+@mixin _oTypographyFor(
+	$font,
+	$scale,
+	$line-height,
+	$weight,
+	$style,
+	$include-font-family,
+	$include-progressive
+) {
 	// Check font variant is supported.
 	$font-without-fallbacks: oFontsGetFontFamilyWithoutFallbacks($font);
 	$variant-exists: oFontsVariantExists($font-without-fallbacks, $weight, $style);
@@ -172,9 +179,9 @@
 	}
 
 	@if $scale {
-		@include _oTypographySize($scale: $scale, $line-height: $custom-line-height, $font: $font);
-	} @else if $custom-line-height {
-		line-height: _oTypographyAdjustUnit($custom-line-height);
+		@include _oTypographySize($scale: $scale, $line-height: $line-height, $font: $font);
+	} @else if $line-height {
+		line-height: _oTypographyAdjustUnit($line-height);
 	}
 
 	@if $weight  {
@@ -185,7 +192,7 @@
 		font-style: unquote($style);
 	}
 
-	@if $progressive {
+	@if $include-progressive {
 		@include _oTypographyProgressiveFontFallback($font, $scale, $weight, $style, $include-font-family);
 	}
 }

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -146,7 +146,7 @@
 /// @access private
 @mixin _oTypographyFor($font, $opts: ()) {
 	// Get options, null default.
-	$family: map-get($opts, 'family');
+	$include-font-family: map-get($opts, 'family');
 	$scale: map-get($opts, 'scale');
 	$custom-line-height: map-get($opts, 'custom-line-height');
 	$weight: map-get($opts, 'weight');
@@ -161,7 +161,7 @@
 		@error 'Font family "#{$font-without-fallbacks}" of weight "#{if($weight, $weight, 'regular')}" and style "#{if($style, $style, 'normal')}" is not supported.';
 	}
 
-	@if $family {
+	@if $include-font-family {
 		font-family: if(type-of($font) == 'string', unquote($font), $font);
 	}
 
@@ -180,7 +180,7 @@
 	}
 
 	@if $progressive {
-		@include _oTypographyProgressiveFontFallback($font, $scale, $weight, $style);
+		@include _oTypographyProgressiveFontFallback($font, $scale, $weight, $style, $include-font-family);
 	}
 }
 

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -202,7 +202,7 @@
 /// parameter for when outputting styles for progressively loaded fonts
 ///
 /// @param {Number} $scale number on scale the sizes are based on
-/// @param {Bool | Number} $line-height size to override the line-height property
+/// @param {Boolean | Number} $line-height size to override the line-height property
 /// @param {String} $font [''] - The font to get the font size for, as fonts may have different scales. Uses the default scale if not specified.
 @mixin _oTypographySize($scale, $line-height: false, $font: '') {
 	@if type-of($scale) == map {

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -166,7 +166,7 @@
 	}
 
 	@if $scale {
-		@include oTypographySize($scale: $scale, $line-height: $custom-line-height, $font: $font);
+		@include _oTypographySize($scale: $scale, $line-height: $custom-line-height, $font: $font);
 	} @else if $custom-line-height {
 		line-height: _oTypographyAdjustUnit($custom-line-height);
 	}
@@ -181,5 +181,36 @@
 
 	@if $progressive {
 		@include _oTypographyProgressiveFontFallback($font, $scale, $weight, $style);
+	}
+}
+
+/// Outputs the font size and line height based on the scale, also
+/// accepts an override line-height to output and a font adjustment
+/// parameter for when outputting styles for progressively loaded fonts
+///
+/// @param {Number} $scale number on scale the sizes are based on
+/// @param {Bool | Number} $line-height size to override the line-height property
+/// @param {String} $font [''] - The font to get the font size for, as fonts may have different scales. Uses the default scale if not specified.
+@mixin _oTypographySize($scale, $line-height: false, $font: '') {
+	@if type-of($scale) == map {
+		@each $breakpoint, $scale in $scale {
+			$current-line-height: if(length($scale) == 2, nth($scale, 2), $line-height);
+			$current-scale: if(type-of($scale) == list and length($scale) != 0, nth($scale, 1), $scale);
+
+			@if $breakpoint == 'default' and $current-scale {
+				font-size: _oTypographyFontSizeFromScale($current-scale, 1, $font);
+				line-height: _oTypographyLineHeightFromScale($current-scale, $current-line-height, $font);
+			}
+
+			@if $breakpoint != 'default' and $current-scale {
+				@include oGridRespondTo($breakpoint) {
+					font-size: _oTypographyFontSizeFromScale($current-scale, 1, $font);
+					line-height: _oTypographyLineHeightFromScale($current-scale, $current-line-height, $font);
+				}
+			}
+		}
+	} @else {
+		font-size: _oTypographyFontSizeFromScale($scale, 1, $font);
+		line-height: _oTypographyLineHeightFromScale($scale, $line-height, $font);
 	}
 }

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -5,23 +5,8 @@
 
 /// Body text styles
 @mixin oTypographyBody {
-	// If family style is not given default to sans.
-	$type: _oTypographyGet('font-type', 'body');
-	$type: if($type, $type, 'sans');
-	$font-family: _oTypographyFontFamilyForType($type);
-	// If scale isn't given default to 1.
-	$scale: _oTypographyGet('scale', 'body');
-	$scale: if($scale, $scale, 1);
-	@include _oTypographyFor($font-family, $opts: (
-		'family': true,
-		'scale': $scale,
-		'custom-line-height':  _oTypographyGet('custom-line-height', 'body'),
-	));
-	// Add bottom margin if set.
-	$bottom-spacing-size: _oTypographyGet('bottom-spacing-size', 'body');
-	@if $bottom-spacing-size {
-		margin: 0 0 oSpacingByIncrement($bottom-spacing-size);
-	}
+	@include oTypographySans(1);
+	margin: 0 0 oSpacingByName('s2');
 	color: oColorsGetColorFor('body', 'text');
 }
 
@@ -182,79 +167,73 @@
 	}
 }
 
-/// Styling for <ul> and <ol>
-@mixin oTypographyList {
-	margin-top: 0;
-	margin-bottom: oSpacingByIncrement(7);
-
-	li {
-		$type: _oTypographyGet('font-type', 'body');
-		$type: if($type, $type, 'sans');
-		$font-family: _oTypographyFontFamilyForType($type);
-		@include _oTypographyFor($font-family, $opts: (
-			'family': true,
-			'scale': 1,
-			'custom-line-height': 28px,
-		));
-		margin-top: 0;
-		margin-bottom: 0;
-		color: oColorsGetColorFor('body', 'text');
+/// Output styles for lists.
+/// Styles child `li` elements. Apply to a
+/// containing list element such as `ul` or `ol`.
+/// Does not output font styles, these are
+/// inherited (@see oTypographyBody).
+///
+/// @example Output the styles for an unordered list.
+///     .my-unordered-list {
+///     	@include oTypographyList('unordered');
+///     }
+///
+/// @example Output the styles for an ordered and unordered list, sharing base list styles.
+///     .my-list {
+///     	@include oTypographyList();
+///     }
+///
+///     .my-list--ordered {
+///     	@include oTypographyList('ordered', $include-base-styles: false);
+///     }
+///
+///     .my-list--unordered {
+///     	@include oTypographyList('unordered', $include-base-styles: false);
+///     }
+///
+/// @param {String|Null} $type [null] - "ordered", "unordered", or null for just the base styles shared by all lists
+/// @param {Boolean} $include-base-styles [true] - set to false to exclude base styles which are shared by all list types
+@mixin oTypographyList($type: null, $include-base-styles: true) {
+	// Undo browser defaults.
+	@if($include-base-styles) {
+		margin: 0;
+		padding: 0;
+		list-style: none;
 	}
-}
-
-/// Styles for <ol> tags
-@mixin oTypographyListOrdered {
-	padding-left: 0;
-
-	// Counter-increment/counter-reset is not supported in
-	// <IE8, so use browserhack to only target supported browsers
-	:root & {
+	// Reset number counter for new ordered list.
+	@if($type == 'ordered') {
 		counter-reset: item;
-
-		> li {
-			display: block;
-			position: relative;
-			padding-left: oSpacingByIncrement(6);
-
-
-			&:before {
-				@include oTypographySans (
-					$scale: 0,
-					$weight: 'semibold'
-				);
-				position: absolute;
+	}
+	> li {
+		// Undo browser defaults.
+		@if($include-base-styles) {
+			margin: 0;
+		}
+		&:before {
+			// Allow space for 2-3 numbers for both ordered and unordered lists,
+			// so content aligns between both list types. As an inline pseudo
+			// element a longer count will push list content rather than overlap.
+			@if($include-base-styles) {
 				display: inline-block;
-				width: oSpacingByIncrement(5);
-				font-feature-settings: "tnum";
-				margin-right: oSpacingByIncrement(-1);
+				box-sizing: border-box;
+				min-width: 3ex;
+				padding-right: oSpacingByName('s1');
+			}
+
+			@if($type == 'unordered') {
+				content: '\2022'; // dot character
+				color: inherit;
+				transform: scale(1.778); // 32px dot character given a parent font-size of 18px
+				transform-origin: center left;
+				margin-left: -0.16ch; // remove kerning and align marker flush to the left
+			}
+
+			@if($type == 'ordered') {
 				content: counter(item);
 				counter-increment: item;
-				left: 0;
-				top: 4px;
-				color: oColorsGetColorFor('body', 'text');
+				font-feature-settings: "tnum";
+				font-family: $o-typography-sans;
 			}
-		}
-	}
-}
-
-/// Styles for <ul> tags
-/// Bullet size and spacing was suited to article font-size (18px at time of writing).
-/// This has since been updated to use `em` units but maintain that ratio.
-@mixin oTypographyListUnordered {
-	padding-left: 0;
-
-	li {
-		display: block;
-		position: relative;
-		padding-left: 1.333333333em; // padding-left 24px for `li` items with font-size of 18px
-
-		&:before {
-			color: oColorsGetColorFor('body', 'text');
-			display: inline-block;
-			position: absolute;
-			content: '\2022'; // dot character
-			left: -0.0625em;
-			font-size: 1.777777778em; // font-size 32px for `li` items with font-size of 18px
 		}
 	}
 }

--- a/src/scss/use-cases/_headings.scss
+++ b/src/scss/use-cases/_headings.scss
@@ -37,31 +37,20 @@
 /// Heading styles.
 /// @access private
 @mixin _oTypographyHeading($from) {
-	// If family style is not given default to sans.
-	$type: _oTypographyGet('font-type', $from);
-	$type: if($type, $type, 'sans');
-	$font-family: _oTypographyFontFamilyForType($type);
-	// If weight is not given default to regular, overriding the browser default.
+	// If weight is not given default to regular,
+	// overriding the browser default.
 	$weight: _oTypographyGet('weight', $from);
 	$weight: if($weight, $weight, 'regular');
-	// If bottom spacing size is not given default to 5.
-	$bottom-spacing-size: _oTypographyGet('bottom-spacing-size', $from);
-	$bottom-spacing-size: if($bottom-spacing-size, $bottom-spacing-size, 5);
-	@include _oTypographyFor($font-family, $opts: (
-		'family': true,
-		'weight': $weight,
-		'scale': (
+	@include oTypographySans(
+		$scale: (
 			default: _oTypographyGet('scale', $from),
 			S: _oTypographyGet('scale-s', $from),
 			M: _oTypographyGet('scale-m', $from),
 			L: _oTypographyGet('scale-l', $from),
 			XL: _oTypographyGet('scale-xl', $from)
 		),
-	));
+		$weight: $weight
+	);
 	color: oColorsGetColorFor('body', 'text');
-	text-transform: _oTypographyGet('text-transform', $from);
-	letter-spacing: _oTypographyGet('letter-spacing', $from);
-	@if $bottom-spacing-size {
-		margin: 0 0 oSpacingByIncrement($bottom-spacing-size);
-	}
+	margin: 0 0 oSpacingByName('s4');
 }

--- a/src/scss/use-cases/_wrapper.scss
+++ b/src/scss/use-cases/_wrapper.scss
@@ -40,15 +40,18 @@
 
 	> ol,
 	> ul {
-		@include oTypographyList;
+		// Output base styles shared by all list types.
+		@include oTypographyList();
 	}
 
 	> ol {
-		@include oTypographyListOrdered;
+		// Output list styles unique to an ordered list.
+		@include oTypographyList($type: 'ordered', $include-base-styles: false);
 	}
 
 	> ul {
-		@include oTypographyListUnordered;
+		// Output list styles unique to an unordered list.
+		@include oTypographyList($type: 'unordered', $include-base-styles: false);
 	}
 
 	> footer {

--- a/src/scss/use-cases/_wrapper.scss
+++ b/src/scss/use-cases/_wrapper.scss
@@ -58,7 +58,7 @@
 	> strong {
 		@include oTypographySans (
 			$weight: 'semibold',
-			$opts: ('font-family': false)
+			$include-font-family: false
 		);
 	}
 

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -91,7 +91,6 @@
 
                 .o-typography--loading-sans & {
                     font-size: 15.66px;
-                    font-family: sans-serif;
                 }
             }
         }
@@ -287,7 +286,6 @@
 
                 .o-typography--loading-display & {
                     font-size: 16.2px;
-                    font-family: serif;
                 }
             }
         }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -81,9 +81,7 @@
     @include test('Does not output a font-family when the option is set to false') {
         @include assert {
             @include output {
-                @include oTypographySans(1, 1.6, $opts: (
-                    'font-family': false
-                ));
+                @include oTypographySans(1, 1.6, $include-font-family: false);
             }
             @include expect {
                 font-size: 18px;
@@ -99,9 +97,7 @@
     @include test('Does not output a progressive font fallback scale when the `progressive` option is set to false') {
         @include assert {
             @include output {
-                @include oTypographySans(1, 1.6, $opts: (
-                    'progressive': false
-                ));
+                @include oTypographySans(1, 1.6, $include-progressive: false);
             }
             @include expect {
                 font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
@@ -182,9 +178,7 @@
     @include test('Does not output a font-family when the option is set to false') {
         @include assert {
             @include output {
-                @include oTypographySerif(1, 1.6, $opts: (
-                    'font-family': false
-                ));
+                @include oTypographySerif(1, 1.6, $include-font-family: false);
             }
             @include expect {
                 font-size: 18px;
@@ -196,9 +190,7 @@
     @include test('Does not output a progressive font fallback scale when the `progressive` option is set to false') {
         @include assert {
             @include output {
-                @include oTypographySerif(1, 1.6, $opts: (
-                    'progressive': false
-                ));
+                @include oTypographySerif(1, 1.6, $include-progressive: false);
             }
             @include expect {
                 font-family: oFontsGetFontFamilyWithFallbacks(Georgia);
@@ -276,9 +268,7 @@
     @include test('Does not output a font-family when the option is set to false') {
         @include assert {
             @include output {
-                @include oTypographyDisplay(1, 1.6, $opts: (
-                    'font-family': false
-                ));
+                @include oTypographyDisplay(1, 1.6, $include-font-family: false);
             }
             @include expect {
                 font-size: 18px;
@@ -294,9 +284,7 @@
     @include test('Does not output a progressive font fallback scale when the `progressive` option is set to false') {
         @include assert {
             @include output {
-                @include oTypographyDisplay(1, 1.6, $opts: (
-                    'progressive': false
-                ));
+                @include oTypographyDisplay(1, 1.6, $include-progressive: false);
             }
             @include expect {
                 font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -374,7 +374,7 @@
     @include test('Includes a font size and line height for a given scale.') {
         @include assert {
             @include output {
-                @include oTypographySize($scale: 1);
+                @include _oTypographySize($scale: 1);
             }
             @include expect {
                 font-size: 18px;
@@ -386,7 +386,7 @@
     @include test('Includes a font size and line height for a given responsive scale.') {
         @include assert {
             @include output {
-                @include oTypographySize($scale: (default: 1, L: 2));
+                @include _oTypographySize($scale: (default: 1, L: 2));
             }
             @include expect {
                 font-size: 18px;
@@ -403,7 +403,7 @@
     @include test('Includes a custom line height for a given scale.') {
         @include assert {
             @include output {
-                @include oTypographySize($scale: 1, $line-height: 1.4);
+                @include _oTypographySize($scale: 1, $line-height: 1.4);
             }
             @include expect {
                 font-size: 18px;
@@ -415,7 +415,7 @@
     @include test('Includes a custom line height for a responsive scale.') {
         @include assert {
             @include output {
-                @include oTypographySize($scale: (default: 1, L: 2), $line-height: 24px);
+                @include _oTypographySize($scale: (default: 1, L: 2), $line-height: 24px);
             }
             @include expect {
                 font-size: 18px;
@@ -432,7 +432,7 @@
     @include test('Includes seperate custom line heights for each scale in a responsive scale.') {
         @include assert {
             @include output {
-                @include oTypographySize($scale: (default: (1, 18px), L: (2, 24px)));
+                @include _oTypographySize($scale: (default: (1, 18px), L: (2, 24px)));
             }
             @include expect {
                 font-size: 18px;
@@ -449,7 +449,7 @@
     @include test('Priorities custom line heights in responsive scales.') {
         @include assert {
             @include output {
-                @include oTypographySize($scale: (default: (1, 18px), L: 2), $line-height: 1.4);
+                @include _oTypographySize($scale: (default: (1, 18px), L: 2), $line-height: 1.4);
             }
             @include expect {
                 font-size: 18px;
@@ -467,7 +467,7 @@
         @include assert {
             @include output {
                 $o-typography-relative-units: true !global;
-                @include oTypographySize($scale: 1);
+                @include _oTypographySize($scale: 1);
                 $o-typography-relative-units: false !global;
             }
             @include expect {
@@ -481,7 +481,7 @@
         @include assert {
             @include output {
                 $o-typography-relative-units: true !global;
-                @include oTypographySize($scale: 1, $line-height: unset);
+                @include _oTypographySize($scale: 1, $line-height: unset);
                 $o-typography-relative-units: false !global;
             }
             @include expect {


### PR DESCRIPTION
We introduced multiple font scales for specialist titles earlier
in the year, so the result of `oTypographySize` depends on the font.

Instead of passing a font type to `oTypographySize` use
`oTypographySans`, `oTypographySerif`, or `oTypographyDisplay` with
arguments instead. This also includes progressive font loading
styles for the updated size, where `oTypographySize` did not.