### PR TITLE
Update list styles and private typography Sass.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,6 +18,8 @@ The following mixins have been replaced:
 - oTypographyLinkExternal: oTypographyLink($external: true);
 - oTypographyLinkExternalIcon: oTypographyLink($external: true, $include-base-styles: false);
 - oTypographySize: oTypographySans($scale: 1, $opts: ('font-family': false))
+- oTypographyListOrdered: oTypographyList($type: 'ordered', $include-base-styles: false)
+- oTypographyListUnordered: oTypographyList($type: 'unordered', $include-base-styles: false)
 
 The following mixins have been updated:
 - oTypographyMaxLineWidth: Returns a relative `ch` rather than `px` value. The `$scale` and `$font` parameters are redundant and have been removed.

--- a/main.scss
+++ b/main.scss
@@ -114,15 +114,18 @@
 
 	@if $lists-enabled {
 		.o-typography-list {
-			@include oTypographyList;
+			// Output base styles shared by all list types.
+			@include oTypographyList();
 		}
 
 		.o-typography-list--ordered {
-			@include oTypographyListOrdered;
+			// Output list styles unique to an ordered list.
+			@include oTypographyList($type: 'ordered', $include-base-styles: false);
 		}
 
 		.o-typography-list--unordered {
-			@include oTypographyListUnordered;
+			// Output list styles unique to an unordered list.
+			@include oTypographyList($type: 'unordered', $include-base-styles: false);
 		}
 	}
 

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -51,9 +51,6 @@ $o-typography-display: '' !default;
 ///        ),
 ///        'heading-level-six': (
 ///            'scale': 2
-///        ),
-///        'body': (
-///            'bottom-spacing-size': 8,
 ///        )
 ///    ));
 @mixin oTypographyCustomize($variables) {
@@ -64,8 +61,7 @@ $o-typography-display: '' !default;
         'heading-level-three',
         'heading-level-four',
         'heading-level-five',
-        'heading-level-six',
-        'body',
+        'heading-level-six'
     );
     @each $brand-variable in map-keys($variables) {
         @if not index($allowed-brand-variables, $brand-variable) {
@@ -116,11 +112,6 @@ $o-typography-display: '' !default;
             'heading-level-six': (
                 'scale': 2,
                 'weight': 'semibold'
-            ),
-            'body': (
-                'font-type': 'serif',
-                'bottom-spacing-size': 7,
-                'custom-line-height': 28px,
             )
         ),
         'supports-variants': ()
@@ -155,9 +146,6 @@ $o-typography-display: '' !default;
             'heading-level-six': (
                 'scale': 2,
                 'weight': 'semibold'
-            ),
-            'body': (
-                'bottom-spacing-size': 7,
             )
         ),
         'supports-variants': ()
@@ -217,9 +205,6 @@ $o-typography-display: '' !default;
             ),
             'heading-level-six': (
                 'scale': 1
-            ),
-            'body': (
-                'bottom-spacing-size': 7,
             )
         ),
         'supports-variants': ()

--- a/src/scss/_type-mixins.scss
+++ b/src/scss/_type-mixins.scss
@@ -37,14 +37,15 @@
 	$include-font-family: true,
 	$include-progressive: true
 ) {
-	@include _oTypographyFor($o-typography-serif, $opts: (
-		'family': $include-font-family,
-		'scale': $scale,
-		'style': $style,
-		'weight': $weight,
-		'custom-line-height': $line-height,
-		'progressive': $include-progressive
-	));
+	@include _oTypographyFor(
+		$o-typography-serif,
+		$scale,
+		$line-height,
+		$weight,
+		$style,
+		$include-font-family,
+		$include-progressive
+	);
 }
 
 /// Outputs typography styles for the Display font.
@@ -86,14 +87,15 @@
 	$include-font-family: true,
 	$include-progressive: true
 ) {
-	@include _oTypographyFor($o-typography-display, $opts: (
-		'family': $include-font-family,
-		'scale': $scale,
-		'style': $style,
-		'weight': $weight,
-		'custom-line-height': $line-height,
-		'progressive': $include-progressive
-	));
+	@include _oTypographyFor(
+		$o-typography-display,
+		$scale,
+		$line-height,
+		$weight,
+		$style,
+		$include-font-family,
+		$include-progressive
+	);
 }
 
 /// Outputs typography styles for the Sans font.
@@ -136,30 +138,35 @@
 	$include-font-family: true,
 	$include-progressive: true
 ) {
-	@include _oTypographyFor($o-typography-sans, $opts: (
-		'family': $include-font-family,
-		'scale': $scale,
-		'style': $style,
-		'weight': $weight,
-		'custom-line-height': $line-height,
-		'progressive': $include-progressive
-	));
+	@include _oTypographyFor(
+		$o-typography-sans,
+		$scale,
+		$line-height,
+		$weight,
+		$style,
+		$include-font-family,
+		$include-progressive
+	);
 }
 
 /// Output a typography for font
 /// @param {String} $font - The font to output typography for.
-/// @param {Map} $opts - What typography styles to output: family (boolean), scale (number -2 - 12), custom-line-height (e.g. 1em), weight (e.g. bold), style (e.g. italic), progressive (boolean).
+/// @param {Null | Number} $scale [null] - a scale number to output a font-size and line-height property
+/// @param {Null | Number} $line-height [null] - custom line-height value to use instead of the scale's default
+/// @param {Null | String} $weight [null] - output a font-weight property, e.g. 'bold', 'semibold'
+/// @param {Null | String} $style [null] - output a font-style property, e.g. 'italic'
+/// @param {Boolean} $include-font-family [true] - Set to false to exclude the font-family property from the output. This is useful when resizing typography, where the given font-family is inherited from a parent element.
+/// @param {Boolean} $include-progressive [true] - Set to false to exclude styles used for progressive font loading (font-family and size fallbacks for loading fonts).
 /// @access private
-@mixin _oTypographyFor($font, $opts: ()) {
-	// Get options, null default.
-	$include-font-family: map-get($opts, 'family');
-	$scale: map-get($opts, 'scale');
-	$custom-line-height: map-get($opts, 'custom-line-height');
-	$weight: map-get($opts, 'weight');
-	$style: map-get($opts, 'style');
-	// Get options, true default.
-	$progressive: if(map-has-key($opts, 'progressive'), map-get($opts, 'progressive'), true);
-
+@mixin _oTypographyFor(
+	$font,
+	$scale,
+	$line-height,
+	$weight,
+	$style,
+	$include-font-family,
+	$include-progressive
+) {
 	// Check font variant is supported.
 	$font-without-fallbacks: oFontsGetFontFamilyWithoutFallbacks($font);
 	$variant-exists: oFontsVariantExists($font-without-fallbacks, $weight, $style);
@@ -172,9 +179,9 @@
 	}
 
 	@if $scale {
-		@include _oTypographySize($scale: $scale, $line-height: $custom-line-height, $font: $font);
-	} @else if $custom-line-height {
-		line-height: _oTypographyAdjustUnit($custom-line-height);
+		@include _oTypographySize($scale: $scale, $line-height: $line-height, $font: $font);
+	} @else if $line-height {
+		line-height: _oTypographyAdjustUnit($line-height);
 	}
 
 	@if $weight  {
@@ -185,7 +192,7 @@
 		font-style: unquote($style);
 	}
 
-	@if $progressive {
+	@if $include-progressive {
 		@include _oTypographyProgressiveFontFallback($font, $scale, $weight, $style, $include-font-family);
 	}
 }

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -5,23 +5,8 @@
 
 /// Body text styles
 @mixin oTypographyBody {
-	// If family style is not given default to sans.
-	$type: _oTypographyGet('font-type', 'body');
-	$type: if($type, $type, 'sans');
-	$font-family: _oTypographyFontFamilyForType($type);
-	// If scale isn't given default to 1.
-	$scale: _oTypographyGet('scale', 'body');
-	$scale: if($scale, $scale, 1);
-	@include _oTypographyFor($font-family, $opts: (
-		'family': true,
-		'scale': $scale,
-		'custom-line-height':  _oTypographyGet('custom-line-height', 'body'),
-	));
-	// Add bottom margin if set.
-	$bottom-spacing-size: _oTypographyGet('bottom-spacing-size', 'body');
-	@if $bottom-spacing-size {
-		margin: 0 0 oSpacingByIncrement($bottom-spacing-size);
-	}
+	@include oTypographySans(1);
+	margin: 0 0 oSpacingByName('s2');
 	color: oColorsGetColorFor('body', 'text');
 }
 
@@ -182,79 +167,73 @@
 	}
 }
 
-/// Styling for <ul> and <ol>
-@mixin oTypographyList {
-	margin-top: 0;
-	margin-bottom: oSpacingByIncrement(7);
-
-	li {
-		$type: _oTypographyGet('font-type', 'body');
-		$type: if($type, $type, 'sans');
-		$font-family: _oTypographyFontFamilyForType($type);
-		@include _oTypographyFor($font-family, $opts: (
-			'family': true,
-			'scale': 1,
-			'custom-line-height': 28px,
-		));
-		margin-top: 0;
-		margin-bottom: 0;
-		color: oColorsGetColorFor('body', 'text');
+/// Output styles for lists.
+/// Styles child `li` elements. Apply to a
+/// containing list element such as `ul` or `ol`.
+/// Does not output font styles, these are
+/// inherited (@see oTypographyBody).
+///
+/// @example Output the styles for an unordered list.
+///     .my-unordered-list {
+///     	@include oTypographyList('unordered');
+///     }
+///
+/// @example Output the styles for an ordered and unordered list, sharing base list styles.
+///     .my-list {
+///     	@include oTypographyList();
+///     }
+///
+///     .my-list--ordered {
+///     	@include oTypographyList('ordered', $include-base-styles: false);
+///     }
+///
+///     .my-list--unordered {
+///     	@include oTypographyList('unordered', $include-base-styles: false);
+///     }
+///
+/// @param {String|Null} $type [null] - "ordered", "unordered", or null for just the base styles shared by all lists
+/// @param {Boolean} $include-base-styles [true] - set to false to exclude base styles which are shared by all list types
+@mixin oTypographyList($type: null, $include-base-styles: true) {
+	// Undo browser defaults.
+	@if($include-base-styles) {
+		margin: 0;
+		padding: 0;
+		list-style: none;
 	}
-}
-
-/// Styles for <ol> tags
-@mixin oTypographyListOrdered {
-	padding-left: 0;
-
-	// Counter-increment/counter-reset is not supported in
-	// <IE8, so use browserhack to only target supported browsers
-	:root & {
+	// Reset number counter for new ordered list.
+	@if($type == 'ordered') {
 		counter-reset: item;
-
-		> li {
-			display: block;
-			position: relative;
-			padding-left: oSpacingByIncrement(6);
-
-
-			&:before {
-				@include oTypographySans (
-					$scale: 0,
-					$weight: 'semibold'
-				);
-				position: absolute;
+	}
+	> li {
+		// Undo browser defaults.
+		@if($include-base-styles) {
+			margin: 0;
+		}
+		&:before {
+			// Allow space for 2-3 numbers for both ordered and unordered lists,
+			// so content aligns between both list types. As an inline pseudo
+			// element a longer count will push list content rather than overlap.
+			@if($include-base-styles) {
 				display: inline-block;
-				width: oSpacingByIncrement(5);
-				font-feature-settings: "tnum";
-				margin-right: oSpacingByIncrement(-1);
+				box-sizing: border-box;
+				min-width: 3ex;
+				padding-right: oSpacingByName('s1');
+			}
+
+			@if($type == 'unordered') {
+				content: '\2022'; // dot character
+				color: inherit;
+				transform: scale(1.778); // 32px dot character given a parent font-size of 18px
+				transform-origin: center left;
+				margin-left: -0.16ch; // remove kerning and align marker flush to the left
+			}
+
+			@if($type == 'ordered') {
 				content: counter(item);
 				counter-increment: item;
-				left: 0;
-				top: 4px;
-				color: oColorsGetColorFor('body', 'text');
+				font-feature-settings: "tnum";
+				font-family: $o-typography-sans;
 			}
-		}
-	}
-}
-
-/// Styles for <ul> tags
-/// Bullet size and spacing was suited to article font-size (18px at time of writing).
-/// This has since been updated to use `em` units but maintain that ratio.
-@mixin oTypographyListUnordered {
-	padding-left: 0;
-
-	li {
-		display: block;
-		position: relative;
-		padding-left: 1.333333333em; // padding-left 24px for `li` items with font-size of 18px
-
-		&:before {
-			color: oColorsGetColorFor('body', 'text');
-			display: inline-block;
-			position: absolute;
-			content: '\2022'; // dot character
-			left: -0.0625em;
-			font-size: 1.777777778em; // font-size 32px for `li` items with font-size of 18px
 		}
 	}
 }

--- a/src/scss/use-cases/_headings.scss
+++ b/src/scss/use-cases/_headings.scss
@@ -37,31 +37,20 @@
 /// Heading styles.
 /// @access private
 @mixin _oTypographyHeading($from) {
-	// If family style is not given default to sans.
-	$type: _oTypographyGet('font-type', $from);
-	$type: if($type, $type, 'sans');
-	$font-family: _oTypographyFontFamilyForType($type);
-	// If weight is not given default to regular, overriding the browser default.
+	// If weight is not given default to regular,
+	// overriding the browser default.
 	$weight: _oTypographyGet('weight', $from);
 	$weight: if($weight, $weight, 'regular');
-	// If bottom spacing size is not given default to 5.
-	$bottom-spacing-size: _oTypographyGet('bottom-spacing-size', $from);
-	$bottom-spacing-size: if($bottom-spacing-size, $bottom-spacing-size, 5);
-	@include _oTypographyFor($font-family, $opts: (
-		'family': true,
-		'weight': $weight,
-		'scale': (
+	@include oTypographySans(
+		$scale: (
 			default: _oTypographyGet('scale', $from),
 			S: _oTypographyGet('scale-s', $from),
 			M: _oTypographyGet('scale-m', $from),
 			L: _oTypographyGet('scale-l', $from),
 			XL: _oTypographyGet('scale-xl', $from)
 		),
-	));
+		$weight: $weight
+	);
 	color: oColorsGetColorFor('body', 'text');
-	text-transform: _oTypographyGet('text-transform', $from);
-	letter-spacing: _oTypographyGet('letter-spacing', $from);
-	@if $bottom-spacing-size {
-		margin: 0 0 oSpacingByIncrement($bottom-spacing-size);
-	}
+	margin: 0 0 oSpacingByName('s4');
 }

--- a/src/scss/use-cases/_wrapper.scss
+++ b/src/scss/use-cases/_wrapper.scss
@@ -40,15 +40,18 @@
 
 	> ol,
 	> ul {
-		@include oTypographyList;
+		// Output base styles shared by all list types.
+		@include oTypographyList();
 	}
 
 	> ol {
-		@include oTypographyListOrdered;
+		// Output list styles unique to an ordered list.
+		@include oTypographyList($type: 'ordered', $include-base-styles: false);
 	}
 
 	> ul {
-		@include oTypographyListUnordered;
+		// Output list styles unique to an unordered list.
+		@include oTypographyList($type: 'unordered', $include-base-styles: false);
 	}
 
 	> footer {


### PR DESCRIPTION
Updates list styles and mixins. Taken from the work in progress
o-editorial-typography (which will be updated to build on these
styles). See https://github.com/Financial-Times/o-editorial-typography/pulls?q=is%3Apr+is%3Aclosed

Updates `oTypographyList`.
Removes `oTypographyListOrdered` and `oTypographyListUnordered`.

Other private Sass has been updated and further brand configuration
which is not needed with o-editorial-typography has been removed.