### PR TITLE
Misk v6

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,8 +11,8 @@ The following mixins have been replaced:
 - oTypographyDisplayBold: oTypographyDisplay($weight: 'bold')
 - oTypographySerifBold: oTypographySerif($weight: 'bold')
 - oTypographySerifItalic: oTypographySerif($style: 'italic')
-- oTypographyBold('sans'): oTypographySans($weight: 'semibold', $include-base-styles: false)
-- oTypographyBold('serif'): oTypographySerif($weight: 'bold', $include-base-styles: false)
+- oTypographyBold('sans'): oTypographySans($weight: 'semibold', $include-font-family: false)
+- oTypographyBold('serif'): oTypographySerif($weight: 'bold', $include-font-family: false)
 - oTypographyItalic: Use the `$style` argument of other mixins. Eg. `oTypographySerif($style: 'italic')`.
 - oTypographyLinkCustom: oTypographyLink($theme: ('base': 'claret', 'hover': 'claret-30'));
 - oTypographyLinkExternal: oTypographyLink($external: true);

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,8 +11,8 @@ The following mixins have been replaced:
 - oTypographyDisplayBold: oTypographyDisplay($weight: 'bold')
 - oTypographySerifBold: oTypographySerif($weight: 'bold')
 - oTypographySerifItalic: oTypographySerif($style: 'italic')
-- oTypographyBold('sans'): oTypographySans($weight: 'semibold', $opts: ('font-family': false))
-- oTypographyBold('serif'): oTypographySerif($weight: 'bold', $opts: ('font-family': false))
+- oTypographyBold('sans'): oTypographySans($weight: 'semibold', $include-base-styles: false)
+- oTypographyBold('serif'): oTypographySerif($weight: 'bold', $include-base-styles: false)
 - oTypographyItalic: Use the `$style` argument of other mixins. Eg. `oTypographySerif($style: 'italic')`.
 - oTypographyLinkCustom: oTypographyLink($theme: ('base': 'claret', 'hover': 'claret-30'));
 - oTypographyLinkExternal: oTypographyLink($external: true);

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,7 +17,7 @@ The following mixins have been replaced:
 - oTypographyLinkCustom: oTypographyLink($theme: ('base': 'claret', 'hover': 'claret-30'));
 - oTypographyLinkExternal: oTypographyLink($external: true);
 - oTypographyLinkExternalIcon: oTypographyLink($external: true, $include-base-styles: false);
-- oTypographySize: oTypographySans($scale: 1, $opts: ('font-family': false))
+- oTypographySize: oTypographySans($scale: 1, $include-font-family: false)
 - oTypographyListOrdered: oTypographyList($type: 'ordered', $include-base-styles: false)
 - oTypographyListUnordered: oTypographyList($type: 'unordered', $include-base-styles: false)
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Unless you're using the Build Service no JS will run automatically. You must eit
 **Constructing o-typography**
 
 ```js
-const oTypography = require('o-typography');
+import oTypography from 'o-typography';
 
 const otypography = new oTypography();
 ```

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "o-fonts": "^3.2.0",
     "o-grid": "^4.3.1",
     "fontfaceobserver": "^2.0.9",
-    "o-icons": ">=4.4.2 <6",
+    "o-icons": "^5.11.2",
     "o-spacing": "^2.0.0",
     "o-normalise": "^1.7.4"
   }

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,3 @@
-/*global require*/
 import './../../main.js';
 
 function setWidths () {

--- a/main.scss
+++ b/main.scss
@@ -14,6 +14,12 @@
 @import 'src/scss/use-cases/headings';
 @import 'src/scss/use-cases/wrapper';
 
+// Load fonts outside the primary mixin
+// as they ay be required by other mixins.
+@if $o-typography-load-fonts == true {
+	@include oFonts();
+}
+
 /// Output all default typography styles.
 @mixin oTypography($opts: (
 	'headings',
@@ -33,10 +39,6 @@
 	$caption-enabled: index($opts, 'caption');
 	$footer-enabled: index($opts, 'footer');
 	$utilities-enabled: index($opts, 'utilities');
-
-	@if $o-typography-load-fonts == true {
-		@include oFonts();
-	}
 
 	// Headings
 	@if $headings-enabled {

--- a/main.scss
+++ b/main.scss
@@ -14,12 +14,6 @@
 @import 'src/scss/use-cases/headings';
 @import 'src/scss/use-cases/wrapper';
 
-// Load fonts outside the primary mixin
-// as they ay be required by other mixins.
-@if $o-typography-load-fonts == true {
-	@include oFonts();
-}
-
 /// Output all default typography styles.
 @mixin oTypography($opts: (
 	'headings',
@@ -147,6 +141,12 @@
 
 // So the build service can output all typography styles.
 @if $o-typography-is-silent == false {
+	// Load fonts outside the primary mixin
+	// as they may be required by other mixins.
+	@if $o-typography-load-fonts == true {
+		@include oFonts();
+	}
+
 	@include oTypography();
 	// Don't output twice
 	$o-typography-is-silent: true !global;


### PR DESCRIPTION
- Correct MIGRATION.md notes
- Remove large o-icons semver range.
- Include o-fonts outside of the primary mixin, so fonts may be loaded for use with other mixins.
- Remove reference to commonjs modules

(todo: write proper migration and readme for the next major)