### PR TITLE
List options. Wrapper correction. Heading level 6.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,7 @@ The class `o-typography--loading-sansBold` is now `o-typography--loading-sans-bo
 
 #### Markup
 
-- Only direct children of `o-typography-wrapper` are styled. If your project nests multiple elements under an element with the `o-typography-wrapper` class, check typography styling on nested elements has not been lost.
+- `o-typography-wrapper` used to style any number of nested child elements. To avoid conflicting with other components `o-typography-wrapper` now only styles direct children plus the direct children of any paragraph element. If your project nests multiple elements under an element with the `o-typography-wrapper` class, check typography styling on nested elements has not been lost.
 - `o-typography-link--external` class must be used along with the `o-typography-link` class.
 - `o-typography-big-number` is removed, replace with [o-big-number](https://github.com/Financial-Times/o-big-number/) markup.
 - `o-typography-blockquote` is removed, replace with [o-quote](https://github.com/Financial-Times/o-quote/) markup.
@@ -272,6 +272,10 @@ For more consistent spacing use a [named space](https://registry.origami.ft.com/
 +$size: oSpacingByName('s1');
 ```
 
+##### oTypographyWrapper
+
+The mixin `oTypographyWrapper` has been removed. Instead include the wrapper class `.o-typography-wrapper` using the `oTypography` mixin. Alternatively use the other typography mixins provided to style elements directly.
+
 ##### Editorial Sass (Master Brand Only)
 
 - `oTypographyCollectionHeader` has been removed. Please contact Origami if your project requires this style to discuss using [o-teaser-collection](https://registry.origami.ft.com/components/o-teaser-collection) styles.
@@ -286,12 +290,6 @@ Editorial typography, such as that used in article pages, has moved to a new com
 - `oTypographyStandfirst` becomes `oEditorialTypographyStandfirst`
 - `oTypographyTimestamp` becomes `oEditorialTypographyBylineTimestamp`
 - `oTypographyReadNext` becomes `oEditorialTypographyReadNext`
-
-The previous default wrapper has been moved to [o-editorial-typography](https://registry.origami.ft.com/components/o-editorial-typography). No changes are required by internal or whitelabel brand products. Include `o-editorial-typography` in your project and update your Sass:
-- `oTypographyWrapper` becomes `oEditorialTypographyWrapper`
-
-The product wrapper is now the default. Previously for the master brand this styled headings in the sans-serif "product" style and everything else in the serif editorial style. This is now consistently non-editorial.
-- `oTypographyWrapper($style: 'product')` becomes `oTypographyWrapper`
 
 For master brand products, the previous default headings have been moved to [o-editorial-typography](https://registry.origami.ft.com/components/o-editorial-typography). No changes are required by internal or whitelabel brand products. Include `o-editorial-typography` in your project and update your markup:
 

--- a/demos/src/wrapper.mustache
+++ b/demos/src/wrapper.mustache
@@ -4,8 +4,9 @@
 	<h3>Heading level 3</h3>
 	<h4>Heading level 4</h4>
 	<h5>Heading level 5</h5>
+	<h6>Heading level 6</h6>
 
-	<p>Body - Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#">Link</a> A rem <strong>excepturi</strong> consequuntur commodi dolores ad <em>laboriosam</em> qui odit ipsum distinctio quos laborum dolore magnam iure rerum, enim deleniti saepe sunt.</p>
+	<p>Body - Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#">Link</a> a rem <strong>excepturi</strong> consequuntur commodi dolores ad <em>laboriosam</em> qui odit ipsum distinctio quos laborum dolore magnam iure rerum, enim deleniti saepe sunt.</p>
 	<p>Lorem ipsum dolor sit amet<sup>Sup</sup>, consectetur adipisicing elit<sub>Sub</sub> reiciendis neque et facilis quidem quasi autem tenetur adipisci eum aut magni atque cupiditate laboriosam. <a href="#">Link Necessitatibus asperiores</a></p>
 
 	<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Deserunt aspernatur aut corporis eius. Neque consequuntur commodi consectetur ullam laudantium saepe.</p>

--- a/main.scss
+++ b/main.scss
@@ -12,25 +12,45 @@
 @import 'src/scss/use-cases/general';
 @import 'src/scss/use-cases/wrapper';
 
-/// Output all default typography styles.
+/// Output o-typography features.
+///
+/// @example Output all o-typography css classes.
+/// 	@include oTypography();
+///
+/// @example Output a granular selection of o-typography css classes. See the [README](https://registry.origami.ft.com/components/o-typography/readme) for a full list of options.
+///     @include oTypography((
+///     	'body': true,
+///     	'headings': (1, 2, 3),
+///     	'lists': ('unordered'),
+///     ));
+///
+/// @param {Map} $opts [('headings': (1, 2, 3, 4, 5, 6), 'wrapper': true, 'body': true, 'links': true, 'lists': ('ordered', 'unordered'), 'caption': true, 'footer': true, 'utilities': true)] - The features of o-typography to output classes for. See the [README](https://registry.origami.ft.com/components/o-typography/readme) for more details.
 @mixin oTypography($opts: (
-	'headings',
-	'wrapper',
-	'body',
-	'links',
-	'lists',
-	'caption',
-	'footer',
-	'utilities',
+	'headings': (1, 2, 3, 4, 5, 6),
+	'wrapper': true,
+	'body': true,
+	'links': true,
+	'lists': ('ordered', 'unordered'),
+	'caption': true,
+	'footer': true,
+	'utilities': true,
 )) {
-	$wrapper-enabled: index($opts, 'wrapper');
-	$headings-enabled: index($opts, 'headings');
-	$body-enabled: index($opts, 'body');
-	$links-enabled: index($opts, 'links');
-	$lists-enabled: index($opts, 'lists');
-	$caption-enabled: index($opts, 'caption');
-	$footer-enabled: index($opts, 'footer');
-	$utilities-enabled: index($opts, 'utilities');
+	$wrapper-enabled: mep-get($opts, 'wrapper');
+	$body-enabled: mep-get($opts, 'body');
+	$links-enabled: mep-get($opts, 'links');
+	$caption-enabled: mep-get($opts, 'caption');
+	$footer-enabled: mep-get($opts, 'footer');
+	$utilities-enabled: mep-get($opts, 'utilities');
+	$headings: map-get($opts, 'headings');
+	$headings: if($headings, $headings, ());
+	@if($headings and type-of($headings) != 'list') {
+		@error ('The "headings" option must be a list of heading levels to include e.g. `(1, 2, 3, 4, 5, 6)`.');
+	}
+	$lists: map-get($opts, 'lists');
+	$lists: if($lists, $lists, ());
+	@if($lists and type-of($lists) != 'list') {
+		@error ('The "lists" option must be a list of list types to include e.g. `(\'ordered\', \'unordered\')`.');
+	}
 
 	// Load fonts within the primary mixin in-case silent mode is on.
 	@if $o-typography-load-fonts == true {
@@ -40,29 +60,13 @@
 	}
 
 	// Headings
-	@if $headings-enabled {
-		.o-typography-heading-level-1 {
-			@include oTypographyHeading($level: 1);
-		}
-
-		.o-typography-heading-level-2 {
-			@include oTypographyHeading($level: 2);
-		}
-
-		.o-typography-heading-level-3 {
-			@include oTypographyHeading($level: 3);
-		}
-
-		.o-typography-heading-level-4 {
-			@include oTypographyHeading($level: 4);
-		}
-
-		.o-typography-heading-level-5 {
-			@include oTypographyHeading($level: 5);
+	@each $level in $headings {
+		.o-typography-heading-level-#{$level} {
+			@include oTypographyHeading($level);
 		}
 	}
 
-	// Body, Links, Lists, etc.
+	// Body, Italic, Superscript, Subscript.
 	@if $utilities-enabled {
 		.o-typography-bold {
 			@include oTypographySans (
@@ -84,12 +88,14 @@
 		}
 	}
 
+	// Body
 	@if $body-enabled {
 		.o-typography-body {
 			@include oTypographyBody;
 		}
 	}
 
+	// Links
 	@if $links-enabled {
 		.o-typography-link {
 			@include oTypographyLink;
@@ -103,29 +109,36 @@
 		}
 	}
 
-	@if $caption-enabled {
-		.o-typography-caption {
-			@include oTypographyCaption;
-		}
-	}
-
-	@if $lists-enabled {
+	// Lists
+	@if length($lists) >= 1 {
 		.o-typography-list {
 			// Output base styles shared by all list types.
 			@include oTypographyList();
 		}
+	}
 
+	@if index($lists, 'ordered') {
 		.o-typography-list--ordered {
 			// Output list styles unique to an ordered list.
 			@include oTypographyList($type: 'ordered', $include-base-styles: false);
 		}
+	}
 
+	@if index($lists, 'unordered') {
 		.o-typography-list--unordered {
 			// Output list styles unique to an unordered list.
 			@include oTypographyList($type: 'unordered', $include-base-styles: false);
 		}
 	}
 
+	// Caption
+	@if $caption-enabled {
+		.o-typography-caption {
+			@include oTypographyCaption;
+		}
+	}
+
+	// Footer
 	@if $footer-enabled {
 		.o-typography-footer {
 			@include oTypographyFooter;
@@ -134,6 +147,7 @@
 
 	// Wrapper
 	@if $wrapper-enabled {
+		.o-typography-wrapper > p,
 		.o-typography-wrapper {
 			@include _oTypographyWrapper;
 		}

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -46,7 +46,7 @@
 /// Body text styles
 @mixin oTypographyBody {
 	@include oTypographySans(1);
-	margin: 0 0 oSpacingByName('s2');
+	margin: 0 0 oSpacingByName('s6');
 	color: oColorsGetColorFor('body', 'text');
 }
 
@@ -236,7 +236,7 @@
 @mixin oTypographyList($type: null, $include-base-styles: true) {
 	// Undo browser defaults.
 	@if($include-base-styles) {
-		margin: 0;
+		margin: 0 0 oSpacingByName('s6');
 		padding: 0;
 		list-style: none;
 	}
@@ -269,6 +269,7 @@
 			}
 
 			@if($type == 'ordered') {
+				@include oTypographySans($weight: 'semibold', $include-font-family: false);
 				content: counter(item);
 				counter-increment: item;
 				font-feature-settings: "tnum";

--- a/src/scss/use-cases/_wrapper.scss
+++ b/src/scss/use-cases/_wrapper.scss
@@ -1,6 +1,9 @@
 /// Typography wrapper
 @mixin _oTypographyWrapper() {
 
+	// Lists inherit font family and size from the wrapper.
+	@include oTypographyBody();
+
 	> h1 {
 		@include oTypographyHeading($level: 1);
 	}
@@ -26,11 +29,11 @@
 	}
 
 	> a {
-		@include oTypographyLink;
+		@include oTypographyLink();
 	}
 
 	> p {
-		@include oTypographyBody;
+		@include oTypographyBody();
 	}
 
 	> ol,
@@ -50,11 +53,11 @@
 	}
 
 	> footer {
-		@include oTypographyFooter;
+		@include oTypographyFooter();
 	}
 
 	> strong {
-		@include oTypographySans (
+		@include oTypographySans(
 			$weight: 'semibold',
 			$include-font-family: false
 		);
@@ -65,14 +68,14 @@
 	}
 
 	> sup {
-		@include oTypographySuper;
+		@include oTypographySuper();
 	}
 
 	> sub {
-		@include oTypographySub;
+		@include oTypographySub();
 	}
 
 	> figcaption {
-		@include oTypographyCaption;
+		@include oTypographyCaption();
 	}
 }


### PR DESCRIPTION
- Bring back heading level 6.
- Correct heading and body margin (using the closest named o-space).
- Correct the weight of ordered list numbers.
- Allow the primary mixin in include list types separately.
- Allow the primary mixin in include headings 1-6 separately.
- Correct MIGRATION.md (oTypographyWrapper is actually private).
- Make o-typography-wrapper more greedy, to style direct children
plus direct children of any child paragraph element -- in v5 the
wrapper styles all nested children.