### PR TITLE
Use text-decoration-thickness where support exists

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -183,7 +183,7 @@
 
 		@supports (text-decoration-thickness: 2px) {
 			border-bottom: 0;
-			text-decoration-thickness: 2px;
+			text-decoration-thickness: 2px; //sass-lint:disable-line no-misspelled-properties
 			text-decoration-line: underline;
 		}
 	}

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -180,26 +180,38 @@
 		text-decoration: none;
 		cursor: pointer;
 		border-bottom: 2px solid;
+
+		@supports (text-decoration-thickness: 2px) {
+			border-bottom: 0;
+			text-decoration-thickness: 2px;
+			text-decoration-line: underline;
+		}
 	}
 
 	// Output base styles shared by all links, or
 	// required for a custom link theme.
 	@if($include-base-styles or $theme) {
 		color: $base-color;
-		border-bottom-color: if($base-color, oColorsMix($base-color, $context-color, $percentage: 20), null);
+		$decoration-color: if($base-color, oColorsMix($base-color, $context-color, $percentage: 20), null);
+		border-bottom-color: $decoration-color;
+		text-decoration-color: $decoration-color;
 	}
 
 	&:hover {
 		@if($include-base-styles or $theme) {
 			color: $hover-color;
-			border-bottom-color: if($base-color, oColorsMix($base-color, $context-color, $percentage: 40), null);
+			$decoration-color: if($base-color, oColorsMix($base-color, $context-color, $percentage: 40), null);
+			border-bottom-color: $decoration-color;
+			text-decoration-color: $decoration-color;
 		}
 	}
 
 	// o-normalise provides extra focus styles for links
 	&:focus {
 		@if($include-base-styles) {
-			border-bottom-color: transparent;
+			$decoration-color: transparent;
+			border-bottom-color: $decoration-color;
+			text-decoration-color: $decoration-color;
 		}
 		@if($include-base-styles or $theme) {
 			color: $hover-color;

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -490,7 +490,7 @@
                 border-bottom: 2px solid;
                 @supports (text-decoration-thickness: 2px) {
                     border-bottom: 0;
-                    text-decoration-thickness: 2px;
+                    text-decoration-thickness: 2px; //sass-lint:disable-line no-misspelled-properties
                     text-decoration-line: underline;
                 }
                 color: #0d7680;

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -488,14 +488,22 @@
                 text-decoration: none;
                 cursor: pointer;
                 border-bottom: 2px solid;
+                @supports (text-decoration-thickness: 2px) {
+                    border-bottom: 0;
+                    text-decoration-thickness: 2px;
+                    text-decoration-line: underline;
+                }
                 color: #0d7680;
                 border-bottom-color: #cfd8d1;
+                text-decoration-color: #cfd8d1;
                 &:hover {
                     color: #08474d;
                     border-bottom-color: #9ec0bd;
+                    text-decoration-color: #9ec0bd;
                 }
                 &:focus {
                     border-bottom-color: transparent;
+                    text-decoration-color: transparent;
                     color: #08474d;
                 }
             }
@@ -512,9 +520,11 @@
             @include expect {
                 color: #990f3d;
                 border-bottom-color: #ebc4c3;
+                text-decoration-color: #ebc4c3;
                 &:hover {
                     color: #4d081f;
                     border-bottom-color: #d697a2;
+                    text-decoration-color: #d697a2;
                 }
                 &:focus {
                     color: #4d081f;


### PR DESCRIPTION
for browsers which don't support `text-decoration-thickness`:

<img width="220" alt="Screenshot 2019-11-01 at 11 49 25" src="https://user-images.githubusercontent.com/10405691/68023093-31ad8b00-fc9e-11e9-979c-3081ef614b44.png">

for browsers which do:

<img width="220" alt="Screenshot 2019-11-01 at 11 49 29" src="https://user-images.githubusercontent.com/10405691/68023069-2195ab80-fc9e-11e9-9134-3cf45c0e554c.png">

closes https://github.com/Financial-Times/o-typography/issues/188