### PR TITLE
Allow link themes to be created using colours and colour names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,9 @@ Set the `$external` argument to to indicate the link leads to a different websit
 
 To create a custom link style set the `$theme` argument. Where `$theme` is a map of configuration including:
 
-- **base**: an [o-colors](https://registry.origami.ft.com/components/o-colors) palette colour name for the link
-- **hover**: an [o-colors](https://registry.origami.ft.com/components/o-colors) palette colour name for link on hover
+- **base**: an [o-colors](https://registry.origami.ft.com/components/o-colors) palette colour name or colour for the link
+- **hover**: an [o-colors](https://registry.origami.ft.com/components/o-colors) palette colour name or colour for link on hover
+- **context** (optional): an [o-colors](https://registry.origami.ft.com/components/o-colors) palette colour name or colour to indicate the background colour behind the link (defaults to paper for the master brand, white otherwise)
 
 ```scss
 .my-custom-link {

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -133,23 +133,26 @@
 		'Found: "#{inspect($theme)}"';
 	}
 	@if(type-of($theme) == 'map') {
+		// Get custom base colour.
 		$theme-base: map-get($theme, 'base');
+		$base-color: if(type-of($theme-base) == 'string', oColorsByName($theme-base), $theme-base);
+		// Get custom hover colour.
 		$theme-hover: map-get($theme, 'hover');
+		$hover-color: if(type-of($theme-hover) == 'string', oColorsByName($theme-hover), $theme-hover);
+		// Get optional context colour.
 		$theme-context: map-get($theme, 'context');
-		@if(type-of($theme-base) != 'string') {
-			@error 'A custom link theme must have a `base` property with a palette colour name e.g. `claret`. But found #{$theme-base}.';
+		@if $theme-context {
+			$context-color: if(type-of($theme-context) == 'string', oColorsByName($theme-context), $theme-context);
 		}
-		@if(type-of($theme-hover) != 'string') {
-			@error 'A custom link theme must have a `hover` property with a palette colour name e.g. `claret`. But found #{$theme-hover}.';
+		// Validate colours given.
+		@if(type-of($base-color) != 'color') {
+			@error 'A custom link theme must have a `base` property with a colour or palette colour name e.g. `claret`. But found #{$theme-base}.';
 		}
-		@if($theme-context and type-of($theme-context) != 'string') {
-			@error 'A custom link theme may optionally have a `context` property with a palette colour name, to indicate the colour of the page behind the link, e.g. `null` or `paper`. But found #{$theme-context}.';
+		@if(type-of($hover-color) != 'color') {
+			@error 'A custom link theme must have a `hover` property with a color or palette colour name e.g. `claret`. But found #{$theme-hover}.';
 		}
-		$base-color: oColorsByName($theme-base);
-		$hover-color: oColorsByName($theme-hover);
-		// theme context is optional, use the default if not set
-		@if($theme-context) {
-			$context-color: oColorsByName($theme-context);
+		@if($theme-context and type-of($context-color) != 'color') {
+			@error 'A custom link theme may optionally have a `context` property with a color or palette colour name, to indicate the colour of the page behind the link, e.g. `null` or `paper`. But found #{$theme-context}.';
 		}
 	}
 

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -532,6 +532,29 @@
             }
         }
     }
+    @include test('outputs styles for a custom theme using hex values') {
+        @include assert {
+            @include output {
+                @include oTypographyLink($theme: (
+                    'base': oColorsByName('claret'),
+                    'hover': oColorsByName('claret-30'),
+                ), $include-base-styles: false);
+            }
+            @include expect {
+                color: #990f3d;
+                border-bottom-color: #ebc4c3;
+                text-decoration-color: #ebc4c3;
+                &:hover {
+                    color: #4d081f;
+                    border-bottom-color: #d697a2;
+                    text-decoration-color: #d697a2;
+                }
+                &:focus {
+                    color: #4d081f;
+                }
+            }
+        }
+    }
     @include test('outputs an icon for an external link') {
         @include assert {
             @include output {


### PR DESCRIPTION
This is so mixes of o-colors palette colours may be used.
(also document the context option)