### PR TITLE
Fix list marker position

### DIFF
--- a/demos/src/lists.mustache
+++ b/demos/src/lists.mustache
@@ -1,9 +1,13 @@
-<ul class="o-typography-list o-typography-list--unordered">
-	<li>List</li>
-	<li>List</li>
-</ul>
+<div class="o-typography-body">
 
-<ol class="o-typography-list o-typography-list--ordered">
-	<li>List ordered</li>
-	<li>List ordered</li>
-</ol>
+	<ul class="o-typography-list o-typography-list--unordered">
+		<li>List</li>
+		<li>List</li>
+	</ul>
+
+	<ol class="o-typography-list o-typography-list--ordered">
+		<li>List ordered</li>
+		<li>List ordered</li>
+	</ol>
+
+</div>

--- a/demos/src/lists.mustache
+++ b/demos/src/lists.mustache
@@ -1,3 +1,4 @@
+<!-- o-typography-body used for demo purposes. List font size, line height, and colour are inherited  -->
 <div class="o-typography-body">
 
 	<ul class="o-typography-list o-typography-list--unordered">
@@ -8,6 +9,34 @@
 	<ol class="o-typography-list o-typography-list--ordered">
 		<li>List ordered</li>
 		<li>List ordered</li>
+	</ol>
+
+</div>
+
+
+<!-- o-typography-body used for demo purposes. List font size, line height, and colour are inherited  -->
+<div class="o-typography-body">
+
+	<ul class="o-typography-list o-typography-list--unordered">
+		<li>
+			<p>List of paragraphs<p>
+			<p>List of paragraphs<p>
+		</li>
+		<li>
+			<p>List of paragraphs<p>
+			<p>List of paragraphs<p>
+		</li>
+	</ul>
+
+	<ol class="o-typography-list o-typography-list--ordered">
+		<li>
+			<p>Ordered list of paragraphs<p>
+			<p>Ordered list of paragraphs<p>
+		</li>
+		<li>
+			<p>Ordered list of paragraphs<p>
+			<p>Ordered list of paragraphs<p>
+		</li>
 	</ol>
 
 </div>

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -284,11 +284,11 @@
 		}
 		&:before {
 			@if($include-base-styles) {
+				@include oTypographySans();
 				display: inline-block;
 				position: absolute;
 				left: 0;
 				transform-origin: center left;
-				@include oTypographySans();
 			}
 
 			@if($type == 'unordered') {

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -274,27 +274,30 @@
 		counter-reset: item;
 	}
 	> li {
-		// Undo browser defaults.
 		@if($include-base-styles) {
-			margin: 0;
+			margin: 0; // Undo browser default.
+			padding-left: calc(3ch - #{oSpacingByName('s1')});
 		}
 		&:before {
 			// Allow space for 2-3 numbers for both ordered and unordered lists,
-			// so content aligns between both list types. As an inline pseudo
-			// element a longer count will push list content rather than overlap.
+			// so content aligns between both list types.
 			@if($include-base-styles) {
 				display: inline-block;
-				box-sizing: border-box;
-				min-width: 3ex;
-				padding-right: oSpacingByName('s1');
+				position: relative;
+				width: 0;
+				left: calc(-3ch + #{oSpacingByName('s1')});
 			}
 
 			@if($type == 'unordered') {
-				content: '\2022'; // dot character
+				content: ''; // dot character
 				color: inherit;
-				transform: scale(1.778); // 32px dot character given a parent font-size of 18px
-				transform-origin: center left;
-				margin-left: -0.16ch; // remove kerning and align marker flush to the left
+				$marker-size: 0.9ex;
+				width: $marker-size;
+				height: $marker-size;
+				margin-right: -$marker-size;
+				border-radius: $marker-size / 2;
+				background: currentColor;
+				vertical-align: middle;
 			}
 
 			@if($type == 'ordered') {
@@ -303,6 +306,12 @@
 				counter-increment: item;
 				font-feature-settings: "tnum";
 				font-family: $_o-typography-sans;
+				// 16px marker given a parent font-size of 18px
+				transform: scale(#{(16 / 18)});
+				transform-origin: center;
+				line-height: #{(18/16)};
+				// magic number to make marker flush to the left
+				margin-left: #{(16 / 18) * -0.16ch};
 			}
 		}
 	}

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -275,29 +275,26 @@
 	}
 	> li {
 		@if($include-base-styles) {
-			margin: 0; // Undo browser default.
+			position: relative;
+			// Undo browser default.
+			margin: 0;
+			// Allow space for 2-3 numbers for both ordered and unordered lists,
+			// so content aligns between both list types.
 			padding-left: calc(3ch - #{oSpacingByName('s1')});
 		}
 		&:before {
-			// Allow space for 2-3 numbers for both ordered and unordered lists,
-			// so content aligns between both list types.
 			@if($include-base-styles) {
 				display: inline-block;
-				position: relative;
-				width: 0;
-				left: calc(-3ch + #{oSpacingByName('s1')});
+				position: absolute;
+				left: 0;
 			}
 
 			@if($type == 'unordered') {
-				content: ''; // dot character
+				content: '\2022'; // dot character
 				color: inherit;
-				$marker-size: 0.9ex;
-				width: $marker-size;
-				height: $marker-size;
-				margin-right: -$marker-size;
-				border-radius: $marker-size / 2;
-				background: currentColor;
-				vertical-align: middle;
+				// 32px marker given a parent font-size of 18px
+				transform: scale(#{(32 / 18)});
+				transform-origin: center;
 			}
 
 			@if($type == 'ordered') {
@@ -309,7 +306,6 @@
 				// 16px marker given a parent font-size of 18px
 				transform: scale(#{(16 / 18)});
 				transform-origin: center;
-				line-height: #{(18/16)};
 				// magic number to make marker flush to the left
 				margin-left: #{(16 / 18) * -0.16ch};
 			}

--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -280,21 +280,24 @@
 			margin: 0;
 			// Allow space for 2-3 numbers for both ordered and unordered lists,
 			// so content aligns between both list types.
-			padding-left: calc(3ch - #{oSpacingByName('s1')});
+			padding-left: calc(2ch + #{oSpacingByName('s1')});
 		}
 		&:before {
 			@if($include-base-styles) {
 				display: inline-block;
 				position: absolute;
 				left: 0;
+				transform-origin: center left;
+				@include oTypographySans();
 			}
 
 			@if($type == 'unordered') {
 				content: '\2022'; // dot character
 				color: inherit;
-				// 32px marker given a parent font-size of 18px
-				transform: scale(#{(32 / 18)});
-				transform-origin: center;
+				// 28px marker given a parent font-size of 18px
+				transform: scale(#{(28 / 18)});
+				// magic number to center marker
+				margin-top: #{(28 / 18) * -0.16ch};
 			}
 
 			@if($type == 'ordered') {
@@ -302,10 +305,8 @@
 				content: counter(item);
 				counter-increment: item;
 				font-feature-settings: "tnum";
-				font-family: $_o-typography-sans;
 				// 16px marker given a parent font-size of 18px
 				transform: scale(#{(16 / 18)});
-				transform-origin: center;
 				// magic number to make marker flush to the left
 				margin-left: #{(16 / 18) * -0.16ch};
 			}


### PR DESCRIPTION
Fix list marker position with support for list block children.
It's a little tricky to get right dynamically without a line-height unit.


parent type: georgia, 18px, 28px line-height
<img width="256" alt="georgia-18-28" src="https://user-images.githubusercontent.com/10405691/69478412-f0fee880-0de9-11ea-856b-33ea8274f2e2.png">

parent type: metric, 20px, 18px line-height
<img width="241" alt="metric-20-18" src="https://user-images.githubusercontent.com/10405691/69478413-f0fee880-0de9-11ea-9238-18fba31cf74f.png">

parent type: metric, 32px, 32px line-height
<img width="385" alt="metric-32-32" src="https://user-images.githubusercontent.com/10405691/69478414-f1977f00-0de9-11ea-8be0-a72db7158cde.png">
