### PR TITLE
Update the primary mixin to support the output of a single heading.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -43,7 +43,7 @@
 	$utilities-enabled: map-get($opts, 'utilities');
 	$headings: map-get($opts, 'headings');
 	$headings: if($headings, $headings, ());
-	@if($headings and type-of($headings) != 'list') {
+	@if($headings and type-of($headings) != 'list' and type-of($headings) != 'number') {
 		@error ('The "headings" option must be a list of heading levels to include e.g. `(1, 2, 3, 4, 5, 6)`.');
 	}
 	$lists: map-get($opts, 'lists');

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,3 +1,58 @@
+@include test-module('oTypography') {
+    @include test('Can output styles for a single heading') {
+        @include assert {
+            @include output {
+                $o-typography-load-fonts: false !global;
+                $o-typography-progressive-font-loading: false !global;
+                @include oTypography(('headings': (1)));
+                $o-typography-load-fonts: true !global;
+                $o-typography-progressive-font-loading: true !global;
+            }
+            @include expect {
+                .o-typography-heading-level-1 {
+                    font-family: MetricWeb, sans-serif;
+                    font-size: 32px;
+                    line-height: 32px;
+                    font-weight: 600;
+                    color: #33302e;
+                    margin: 0 0 16px;
+                }
+            }
+        }
+    }
+
+    @include test('Can output styles for multiple headings') {
+        @include assert {
+            @include output($selector: false) {
+                $o-typography-load-fonts: false !global;
+                $o-typography-progressive-font-loading: false !global;
+                @include oTypography(('headings': (1, 2)));
+                $o-typography-load-fonts: true !global;
+                $o-typography-progressive-font-loading: true !global;
+            }
+            @include expect($selector: false) {
+                .o-typography-heading-level-1 {
+                    font-family: MetricWeb, sans-serif;
+                    font-size: 32px;
+                    line-height: 32px;
+                    font-weight: 600;
+                    color: #33302e;
+                    margin: 0 0 16px;
+                }
+
+                .o-typography-heading-level-2 {
+                    font-family: MetricWeb, sans-serif;
+                    font-size: 28px;
+                    line-height: 32px;
+                    font-weight: 600;
+                    color: #33302e;
+                    margin: 0 0 16px;
+                }
+            }
+        }
+    }
+}
+
 @include test-module('oTypographySans') {
     @include test('Outputs a font family.') {
         @include assert {


### PR DESCRIPTION
This previously errored:

```scss
@include oTypography($opts: (
	'headings': (1)
));
```
>The "headings" option must be a list of heading levels to include e.g. `(1, 2, 3, 4, 5)`.

That's because
```scss
$a: type-of((1)) // number
$a: type-of((1,)) // list
```

https://github.com/Financial-Times/o-typography/issues/241