### PR TITLE
Make sure $icon-padding-calc concatenates correctly as a calc and not…

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -162,7 +162,7 @@
 		$icon-color: if($base-color, $base-color, oColorsByName('black'));
 		$icon-size: 1em;
 		$icon-inbuilt-padding-size: #{$icon-size / 4};
-		$icon-padding-calc: #{$icon-size} + 0.5ch;
+		$icon-padding-calc: calc(#{$icon-size} + 0.5ch);
 		@include oIconsContent('outside-page', $icon-color, $size: null, $include-base-styles: false);
 		background-repeat: no-repeat;
 		// Add padding for icon background.


### PR DESCRIPTION
… a string

Without this change, dart-sass would produce this error:

```
  Erroneous area:
1: 1em0.5ch - 0.25em - 0.25em
^..^
```

https://www.sassmeister.com/gist/8cde2b80deba9cfe9504e1d8f87f0895