### PR TITLE
Remove use of a nested CSS `calc` function.

### DIFF
--- a/src/scss/use-cases/_general.scss
+++ b/src/scss/use-cases/_general.scss
@@ -162,7 +162,7 @@
 		$icon-color: if($base-color, $base-color, oColorsByName('black'));
 		$icon-size: 1em;
 		$icon-inbuilt-padding-size: #{$icon-size / 4};
-		$icon-padding-calc: calc(#{$icon-size} + 0.5ch);
+		$icon-padding-calc: "#{$icon-size} + #{0.5ch}";
 		@include oIconsContent('outside-page', $icon-color, $size: null, $include-base-styles: false);
 		background-repeat: no-repeat;
 		// Add padding for icon background.

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -617,6 +617,7 @@
             }
             @include contains {
                 background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:outside-page?source=origami-build-tools&tint=%230D7680,%230D7680&format=svg");
+                padding-right: calc(1em + 0.5ch - 0.25em - 0.25em);
             }
         }
     }


### PR DESCRIPTION
Nested calc functions are not supported in IE11.

Relates to: https://github.com/Financial-Times/o-typography/pull/243