### PR TITLE
Error when font not included

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,18 +152,38 @@ To include typography styles granularly pass an options argument with the featur
 Calling `oTypography` will output font faces to download custom Financial Times fonts. However IE11 may download fonts which are not used. To include font faces more granularly based on your use of o-typography set `$o-typography-load-fonts: false` and use [o-fonts](https://registry.origami.ft.com/components/o-fonts).
 
 ```scss
-// configure o-typography to not include fonts
-$o-typography-load-fonts: false;
 // import dependencies
 @import 'o-typography/main';
 @import 'o-fonts/main';
-// include css for select fonts manually
-@include oFontsInclude(MetricWeb, regular);
-@include oFontsInclude(FinancierDisplayWeb, regular);
-@include oFontsInclude(FinancierDisplayWeb, bold);
+// configure o-typography to not include fonts
+$o-typography-load-fonts: false;
+// include a limited set of recommended font families manually
+@include oFonts($opts: ('recommended': true));
 // include css for all typography
 @include oTypography();
 ```
+
+If an `oTypography` mixin outputs a font family/weight/style for a font face which hasn't been included in the project it is possible to throw an error by setting `$o-typography-error-for-missing-fonts` to an error message. A custom error message is useful as what the engineer should do depends on the project.
+
+```scss
+// import dependencies
+@import 'o-typography/main';
+@import 'o-fonts/main';
+// configure o-typography to not include fonts
+$o-typography-load-fonts: false;
+// error if a font is used which has not been included
+$o-typography-error-for-missing-fonts: 'This project only allows MetricWeb regular! No fun for you without first discussing performance with the Font Guardians of this project.';
+// include a limited set of recommended font families manually
+@include oFonts($opts: ('recommended': true));
+// try to use a font which is not recommended,
+// and has not been included with o-fonts
+.fancy-typography-used-only-here {
+  // throws an error which includes the `$o-typography-error-for-missing-fonts` message.
+  // a thin/italic font face has not been included
+  @include oTypographySans($scale: 1, $weight: 'thin', $style: 'italic');
+}
+```
+
 
 The Sass in o-typography also provides several mixins for use in your project. To explore all functions/mixins see the [SassDoc documentation](sassdoc) in the registry.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ If an `oTypography` mixin outputs a font family/weight/style for a font face whi
 // configure o-typography to not include fonts
 $o-typography-load-fonts: false;
 // error if a font is used which has not been included
-$o-typography-error-for-missing-fonts: 'This project only allows MetricWeb regular! No fun for you without first discussing performance with the Font Guardians of this project.';
+$o-typography-error-for-missing-fonts: 'This project only allows recommended o-fonts! No fun for you without first discussing performance with the Font Guardians of this project.';
 // include a limited set of recommended font families manually
 @include oFonts($opts: ('recommended': true));
 // try to use a font which is not recommended,
@@ -180,7 +180,7 @@ $o-typography-error-for-missing-fonts: 'This project only allows MetricWeb regul
 .fancy-typography-used-only-here {
   // throws an error which includes the `$o-typography-error-for-missing-fonts` message.
   // a thin/italic font face has not been included
-  @include oTypographySans($scale: 1, $weight: 'thin', $style: 'italic');
+  @include oTypographySans($scale: 1, $weight: 'thin', $style: 'normal');
 }
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "o-colors": "^5.0.0",
-    "o-fonts": "^4.1.0",
+    "o-fonts": "^4.3.0",
     "o-grid": "^5.0.0",
     "fontfaceobserver": "^2.0.9",
     "o-icons": "^6.0.0",

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,6 +1,6 @@
-$o-typography-is-silent: false;
-
 @import '../../main';
+
+@include oTypography();
 
 html {
 	background-color: oColorsByUsecase('page', 'background');

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -233,7 +233,19 @@
 	$font-without-fallbacks: oFontsGetFontFamilyWithoutFallbacks($font);
 	$variant-exists: oFontsVariantExists($font-without-fallbacks, $weight, $style);
 	@if not $variant-exists {
-		@error 'Font family "#{$font-without-fallbacks}" of weight "#{if($weight, $weight, 'regular')}" and style "#{if($style, $style, 'normal')}" is not supported.';
+		@error 'Font family "#{$font-without-fallbacks}" of weight ' +
+		'"#{if($weight, $weight, 'regular')}" and style ' +
+		'"#{if($style, $style, 'normal')}" is not supported.';
+	}
+
+	// Check font variant has been included, and error if an error message
+	// has been set by the user.
+	$variant-included: oFontsVariantIncluded($font-without-fallbacks, $weight, $style);
+	@if not $variant-included and type-of($o-typography-error-for-missing-fonts) == 'string' {
+		@error 'The font face for font family "#{$font-without-fallbacks}" of ' +
+		'weight "#{if($weight, $weight, 'regular')}" and style ' +
+		'"#{if($style, $style, 'normal')}" has not been included in your ' +
+		'project. #{inspect($o-typography-error-for-missing-fonts)}';
 	}
 
 	@if $include-font-family {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,7 +3,8 @@
 $o-typography-is-silent: true !default;
 
 /// Use relative units (rem) or not (px) when outputting typographic styles.
-/// When `true`, the user will be able to modify their font size using browser settings.
+/// When `true`, the user will be able to modify their font size using browser
+/// settings.
 ///
 /// For legacy reasons, this defaults to `false` (outputs px units).
 /// Components and projects may need to be updated to support relative units.
@@ -13,6 +14,11 @@ $o-typography-relative-units: false !default;
 /// When true, webfonts will be downloaded
 /// @type Bool
 $o-typography-load-fonts: true !default;
+
+/// The error message to throw if o-typography is used to apply a font face
+/// which has not been included by the project. By default no error is thrown.
+/// @type String|Null
+$o-typography-error-for-missing-fonts: null !default;
 
 /// When true, progressive font fallbacks are output.
 /// @type Bool
@@ -32,15 +38,17 @@ $_o-typography-loading-prefix: 'o-typography--loading' !default;
 $_o-typography-types: ('sans', 'serif', 'display');
 
 /// Font scale of font-sizes and line-heights.
-/// Currently the default scale `$_o-typography-font-scale` is used for all fonts and brands,
-/// but branded products may choose to define their own scale on a per font basis.
+/// Currently the default scale `$_o-typography-font-scale` is used for all
+/// fonts and brands, but branded products may choose to define their own scale
+/// on a per font basis.
 /// @access private
 /// @see oTypographyDefineFontScale
 /// @type Map
 $_o-typography-font-scale-by-font: () !default;
 
 /// Configuration for fallback fonts when loading fonts progressively.
-/// Currently only supports fallbacks for MetricWeb and FinancierDisplayWeb fonts.
+/// Currently only supports fallbacks for MetricWeb and FinancierDisplayWeb
+/// fonts.
 /// @type Map
 $_o-typography-progressive-font-fallbacks: (
 	(


### PR DESCRIPTION
Adds the option to error if a font variant (family/weight/style)
is used when a font face for that variant has not been included in
the project. By default no error is thrown unless the Sass variable
`$o-typography-error-for-missing-fonts` is set to a string (a
message to include in the error).

This will allow projects like PageKit to remove fonts and inform
dependent projects what to do with a custom error message.

We may want to make an error the default behaviour in a future major
version of o-typography.

Relates to: https://github.com/Financial-Times/o-typography/issues/249

