### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import * as fixtures from './helpers/fixtures';
 
 import Typography from './../main';

--- a/test/typography.test.js
+++ b/test/typography.test.js
@@ -1,8 +1,7 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import FontFaceObserver from 'fontfaceobserver/fontfaceobserver.standalone.js';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
 
+import FontFaceObserver from 'fontfaceobserver/fontfaceobserver.standalone.js';
 import Typography from './../main';
 
 const fontLabels = ['display', 'sans', 'sans-bold', 'display-bold'];


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.