### PR TITLE
Link to issue on why to keep custom progressive font loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ p {
 }
 ```
 
+_To remove the need for o-typography's progressive font loading on ft.com, and the fallback font resizing it gives us, [may require work across ft.com projects](https://github.com/Financial-Times/o-typography/issues/248)._
+
 #### Disable Progressive Loading
 
 If you do not want to use `o-typography` progressive font loading set `$o-typography-progressive-font-loading: false;` at the top of your project before importing components:


### PR DESCRIPTION
There are good reasons to remove our custom progressive font
loading, but also things to do/trade offs if we were to decide to
remove it. Add a link from the README which provides that
information.

Prompted by this question:
https://financialtimes.slack.com/archives/C02FU5ARJ/p1587634959151800