### PR TITLE
remove npm dependencies, which are a deviation from the spec :o

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,5 @@
 {
 	"private": true,
-	"dependencies": {
-		"fontfaceobserver": "^2.0.9",
-		"superstore-sync": "^2.1.0"
-	},
 	"name": "o-typography",
 	"devDependencies": {
 		"eslint-config-origami-component": "^2.0.1",


### PR DESCRIPTION
[the npm section of the component spec](https://origami.ft.com/spec/v1/components/#npm) says that components' `package.json`s **must not** include the `dependencies` property

However, this component does contain npm dependencies:
https://github.com/Financial-Times/o-typography/blob/master/package.json#L3-L6

One of these dependencies is also listed in the bower.json:
https://github.com/Financial-Times/o-typography/blob/master/bower.json#L14

the other dependency is available in bower... but also it appears not to be used?:
https://github.com/Financial-Times/o-typography/pull/115

i think it was missed in PR #115