### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import oTypography from './src/js/typography';
+import oTypography from './src/js/typography.js';
 
 const constructAll = function() {
 	oTypography.init();

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import Typography from './../main';
+import Typography from './../main.js';
 
 describe("Typography", () => {
 	it('is defined', () => {

--- a/test/typography.test.js
+++ b/test/typography.test.js
@@ -2,7 +2,7 @@
 /* global proclaim sinon */
 
 import FontFaceObserver from 'fontfaceobserver/fontfaceobserver.standalone.js';
-import Typography from './../main';
+import Typography from './../main.js';
 
 const fontLabels = ['display', 'sans', 'sans-bold', 'display-bold'];
 const prefix = 'o-typography--loading-';


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing