### PR TITLE
Require the latest o-fonts release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "o-colors": "^5.0.0",
-    "o-fonts": "^4.4.0",
+    "o-fonts": "^4.5.0",
     "o-grid": "^5.0.0",
     "fontfaceobserver": "^2.0.9",
     "o-icons": "^6.0.0",


### PR DESCRIPTION
dotcom-page-kit preloads font files using JS. It needs to match
the font files used by o-typography, which we can achieve by
requiring the most recent o-fonts version or later.
https://github.com/Financial-Times/dotcom-page-kit/pull/826

In the future o-fonts should provide a JS api to get the
font url used for preloading. Perhaps in design token form